### PR TITLE
Add .node to main file path & Add --ignore-scripts to preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-block",
-  "main": "./build/Release/ad-block",
+  "main": "./build/Release/ad-block.node",
   "version": "2.0.4",
   "description": "Ad block engine used in the Brave browser for ABP filter syntax based lists like EasyList.",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "build": "make",
     "sample": "make sample",
     "perf": "make perf",
-    "preinstall": "npm install bloom-filter-cpp && npm install hashset-cpp --ignore-scripts",
     "install": "node-gyp rebuild",
     "lint": "npm run lint-cpp && npm run lint-js",
     "lint-cpp": "./scripts/cpplint.py",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "make",
     "sample": "make sample",
     "perf": "make perf",
-    "preinstall": "npm install bloom-filter-cpp && npm install hashset-cpp",
+    "preinstall": "npm install bloom-filter-cpp && npm install hashset-cpp --ignore-scripts",
     "install": "node-gyp rebuild",
     "lint": "npm run lint-cpp && npm run lint-js",
     "lint-cpp": "./scripts/cpplint.py",


### PR DESCRIPTION
**Add .node to main file path:** Small but important. Without this, ESLint will not detect ad-block correctly (https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md). Also, Spectron won't launch on macOS.

**Remove preinstall:** The packages are included in `dependencies` already. This script conflicts with `electron-builder`. https://ci.appveyor.com/project/webcatalog/webcatalog/build/55. Package stops working with this removal > 

Update: Add `--ignore-scripts" solve the problems.