### PR TITLE
Block coin miners by default with Brave shields up

### DIFF
--- a/lib/defaultAdblockLists.js
+++ b/lib/defaultAdblockLists.js
@@ -18,6 +18,11 @@ module.exports = [
     listURL: 'https://raw.githubusercontent.com/brave/adblock-lists/master/brave-unbreak.txt',
     title: 'Brave Unblock',
     supportURL: 'https://github.com/brave/adblock-lists'
+  }, {
+    uuid: 'BCDF774A-7845-4121-B7EB-77EB66CEDF84',
+    listURL: 'https://raw.githubusercontent.com/brave/adblock-lists/master/coin-miners.txt',
+    title: 'Coin Miners',
+    supportURL: 'https://github.com/brave/adblock-lists'
   }
 ]
 


### PR DESCRIPTION
Coin mining in the browser is sometimes abused and can lead to greater CPU usage, especially bad on mobile. 

I'm in favour of it. 