### PR TITLE
fix path of node-gyp in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .PHONY: clean
 
 build:
-	 ./node_modules/.bin/node-gyp configure && node-gyp build
+	 ./node_modules/.bin/node-gyp configure && ./node_modules/.bin/node-gyp build
 
 test:
 	./node_modules/node-gyp/gyp/gyp_main.py --generator-output=./build --depth=. -f ninja test/binding.gyp


### PR DESCRIPTION
Second call to node-gyp in build rule calls globally installed version rather than the one from node_modules.