### PR TITLE
Added option to preserve original filter text

### DIFF
--- a/ad_block_client.cc
+++ b/ad_block_client.cc
@@ -213,7 +213,8 @@ void parseFilter(const char *input, Filter *f, BloomFilter *bloomFilter,
     BloomFilter *exceptionBloomFilter,
     HashSet<Filter> *hostAnchoredHashSet,
     HashSet<Filter> *hostAnchoredExceptionHashSet,
-    HashSet<CosmeticFilter> *simpleCosmeticFilters) {
+    HashSet<CosmeticFilter> *simpleCosmeticFilters,
+    bool preserveRules) {
   const char *end = input;
   while (*end != '\0') end++;
   parseFilter(input, end, f, bloomFilter, exceptionBloomFilter,
@@ -236,9 +237,12 @@ void parseFilter(const char *input, const char *end, Filter *f,
     BloomFilter *exceptionBloomFilter,
     HashSet<Filter> *hostAnchoredHashSet,
     HashSet<Filter> *hostAnchoredExceptionHashSet,
-    HashSet<CosmeticFilter> *simpleCosmeticFilters) {
+    HashSet<CosmeticFilter> *simpleCosmeticFilters,
+    bool preserveRules) {
   FilterParseState parseState = FPStart;
   const char *p = input;
+  const char *filterRuleStart = p;
+  const char *filterRuleEndPos = p;
   char data[kMaxLineLength];
   memset(data, 0, sizeof data);
   int i = 0;
@@ -260,6 +264,7 @@ void parseFilter(const char *input, const char *end, Filter *f,
         case '|':
           if (parseState == FPStart || parseState == FPPastWhitespace) {
             parseState = FPOneBar;
+            filterRuleEndPos++;
             p++;
             continue;
           } else if (parseState == FPOneBar) {
@@ -267,6 +272,7 @@ void parseFilter(const char *input, const char *end, Filter *f,
             f->filterType =
               static_cast<FilterType>(f->filterType | FTHostAnchored);
             parseState = FPData;
+            filterRuleEndPos++;
             p++;
 
             int len = findFirstSeparatorChar(p, end);
@@ -287,6 +293,7 @@ void parseFilter(const char *input, const char *end, Filter *f,
             f->filterType =
               static_cast<FilterType>(f->filterType | FTRightAnchored);
             parseState = FPData;
+            filterRuleEndPos++;
             p++;
             continue;
           }
@@ -294,12 +301,14 @@ void parseFilter(const char *input, const char *end, Filter *f,
         case '@':
           if (parseState == FPStart || parseState == FPPastWhitespace) {
             parseState = FPOneAt;
+            filterRuleEndPos++;
             p++;
             continue;
           } else if (parseState == FPOneAt) {
             parseState = FPOneBar;
             f->filterType = FTException;
             parseState = FPPastWhitespace;
+            filterRuleEndPos++;
             p++;
             continue;
           }
@@ -318,6 +327,8 @@ void parseFilter(const char *input, const char *end, Filter *f,
         case ' ':
           // Skip leading whitespace
           if (parseState == FPStart) {
+            filterRuleStart++;
+            filterRuleEndPos++;
             p++;
             continue;
           }
@@ -331,6 +342,13 @@ void parseFilter(const char *input, const char *end, Filter *f,
               f->data = new char[len];
               f->data[len - 1] = '\0';
               memcpy(f->data, input + i + 1, len - 1);
+
+              if (preserveRules) {
+                f->ruleDefinition = new char[len];
+                f->ruleDefinition[len - 1] = '\0';
+                memcpy(f->ruleDefinition, input + i + 1, len - 1);
+              }
+
               f->filterType = FTRegex;
               return;
             } else {
@@ -340,6 +358,9 @@ void parseFilter(const char *input, const char *end, Filter *f,
           break;
         }
         case '$':
+          // Handle adguard HTML filtering rules syntax
+          // e.g. example.org$$script[data-src="banner"]
+          // see https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#html-filtering-rules-syntax-1
           if (*(p+1) == '$') {
               if (i != 0) {
                 f->domainList = new char[i + 1];
@@ -348,8 +369,12 @@ void parseFilter(const char *input, const char *end, Filter *f,
               }
               parseState = FPDataOnly;
               f->filterType = FTHTMLFiltering;
-              p+=2;
+              p += 2;
+              filterRuleEndPos += 2;
               continue;
+          }
+          while (*filterRuleEndPos != '\0' && !isEndOfLine(*filterRuleEndPos)) {
+            filterRuleEndPos++;
           }
           f->parseOptions(p + 1);
           earlyBreak = true;
@@ -390,12 +415,20 @@ void parseFilter(const char *input, const char *end, Filter *f,
     }
     data[i] = *p;
     i++;
+    filterRuleEndPos++;
     p++;
   }
 
   if (parseState == FPStart) {
     f->filterType = FTEmpty;
     return;
+  }
+
+  if (preserveRules) {
+    int ruleTextLength = filterRuleEndPos - filterRuleStart;
+    f->ruleDefinition = new char[ruleTextLength + 1];
+    memcpy(f->ruleDefinition, filterRuleStart, ruleTextLength);
+    f->ruleDefinition[ruleTextLength] = '\0';
   }
 
   data[i] = '\0';
@@ -879,7 +912,7 @@ bool AdBlockClient::matches(const char *input, FilterOption contextOption,
 }
 
 /**
- * Obtains the first matching filter or nullptrl, and if one is found, finds
+ * Obtains the first matching filter or nullptr, and if one is found, finds
  * the first matching exception filter or nullptr.
  *
  * @return true if the filter should be blocked
@@ -993,9 +1026,9 @@ void setFilterBorrowedMemory(Filter *filters, int numFilters) {
   }
 }
 
-// Parses the filter data into a few collections of filters and enables efficent
-// querying.
-bool AdBlockClient::parse(const char *input) {
+// Parses the filter data into a few collections of filters and enables
+// efficent querying.
+bool AdBlockClient::parse(const char *input, bool preserveRules) {
   // If the user is parsing and we have regex support,
   // then we can determine the fingerprints for the bloom filter.
   // Otherwise it needs to be done manually via initBloomFilter and
@@ -1318,7 +1351,8 @@ bool AdBlockClient::parse(const char *input) {
       parseFilter(lineStart, p, &f, bloomFilter, exceptionBloomFilter,
           hostAnchoredHashSet,
           hostAnchoredExceptionHashSet,
-          &simpleCosmeticFilters);
+          &simpleCosmeticFilters,
+          preserveRules);
       if (!f.hasUnsupportedOptions()) {
         switch (f.filterType & FTListTypesMask) {
           case FTException:

--- a/ad_block_client.h
+++ b/ad_block_client.h
@@ -24,7 +24,8 @@ class AdBlockClient {
   ~AdBlockClient();
 
   void clear();
-  bool parse(const char *input);
+//   bool parse(const char *input);
+  bool parse(const char *input, bool preserveRules = false);
   bool matches(const char *input,
       FilterOption contextOption = FONoFilterOption,
       const char *contextDomain = nullptr);
@@ -116,13 +117,15 @@ void parseFilter(const char *input, const char *end, Filter *f,
     BloomFilter *exceptionBloomFilter = nullptr,
     HashSet<Filter> *hostAnchoredHashSet = nullptr,
     HashSet<Filter> *hostAnchoredExceptionHashSet = nullptr,
-    HashSet<CosmeticFilter> *simpleCosmeticFilters = nullptr);
+    HashSet<CosmeticFilter> *simpleCosmeticFilters = nullptr,
+    bool preserveRules = false);
 void parseFilter(const char *input, Filter *f,
     BloomFilter *bloomFilter = nullptr,
     BloomFilter *exceptionBloomFilter = nullptr,
     HashSet<Filter> *hostAnchoredHashSet = nullptr,
     HashSet<Filter> *hostAnchoredExceptionHashSet = nullptr,
-    HashSet<CosmeticFilter> *simpleCosmeticFilters = nullptr);
+    HashSet<CosmeticFilter> *simpleCosmeticFilters = nullptr,
+    bool preserveRules = false);
 bool isSeparatorChar(char c);
 int findFirstSeparatorChar(const char *input, const char *end);
 

--- a/ad_block_client_wrap.cc
+++ b/ad_block_client_wrap.cc
@@ -224,11 +224,12 @@ void AdBlockClientWrap::Clear(const FunctionCallbackInfo<Value>& args) {
 void AdBlockClientWrap::Parse(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   String::Utf8Value str(isolate, args[0]->ToString());
+  bool preserveRules(args[1]->BooleanValue());
   const char * buffer = *str;
 
   AdBlockClientWrap* obj =
     ObjectWrap::Unwrap<AdBlockClientWrap>(args.Holder());
-  obj->parse(buffer);
+  obj->parse(buffer, preserveRules);
 }
 
 void AdBlockClientWrap::Matches(const FunctionCallbackInfo<Value>& args) {
@@ -271,10 +272,18 @@ void AdBlockClientWrap::FindMatchingFilters(
   if (matchingFilter) {
     foundData->Set(String::NewFromUtf8(isolate, "matchingFilter"),
       String::NewFromUtf8(isolate, matchingFilter->data));
+    if (matchingFilter->ruleDefinition != nullptr) {
+      foundData->Set(String::NewFromUtf8(isolate, "matchingOrigRule"),
+        String::NewFromUtf8(isolate, matchingFilter->ruleDefinition));
+    }
   }
   if (matchingExceptionFilter) {
     foundData->Set(String::NewFromUtf8(isolate, "matchingExceptionFilter"),
       String::NewFromUtf8(isolate, matchingExceptionFilter->data));
+    if (matchingExceptionFilter->ruleDefinition != nullptr) {
+      foundData->Set(String::NewFromUtf8(isolate, "matchingExceptionOrigRule"),
+        String::NewFromUtf8(isolate, matchingExceptionFilter->ruleDefinition));
+    }
   }
   args.GetReturnValue().Set(foundData);
 }

--- a/filter.h
+++ b/filter.h
@@ -55,7 +55,8 @@ enum FilterOption {
   FOPing = 0100000,
   // Not supported, but we will ignore these rules
   FOPopup = 0200000,
-  // This is only used by uBlock and currently all instances are 1x1 transparent gif which we already do for images
+  // This is only used by uBlock and currently all instances are 1x1
+  // transparent gif which we already do for images
   FORedirect = 0400000,
   // Parse CSPs but consider them unsupported
   FOCSP = 01000000,
@@ -178,6 +179,10 @@ friend class AdBlockClient;
   FilterType filterType;
   FilterOption filterOption;
   FilterOption antiFilterOption;
+
+  // The text of the filter list rule, as it appeared before being parsed.
+  char *ruleDefinition;
+
   char *data;
   int dataLen;
   char *domainList;

--- a/protocol.cc
+++ b/protocol.cc
@@ -8,7 +8,7 @@
 
 // Macro for telling -Wimplicit-fallthrough that a fallthrough is intentional.
 #if defined(__clang__)
-#define FALLTHROUGH [[clang::fallthrough]]
+#define FALLTHROUGH[[clang::fallthrough]]
 #else
 #define FALLTHROUGH
 #endif

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -9,6 +9,7 @@
       "../test/rule_types_test.cc",
       "../test/cosmetic_filter_test.cc",
       "../test/protocol_test.cc",
+      "../test/orig_filters_test.cc",
       "../test/util.cc",
       "../protocol.cc",
       "../protocol.h",

--- a/test/orig_filters_test.cc
+++ b/test/orig_filters_test.cc
@@ -1,0 +1,143 @@
+/* Copyright (c) 2015 Brian R. Bondy. Distributed under the MPL2 license.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <string.h>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <cerrno>
+#include <algorithm>
+#include <iostream>
+#include <set>
+#include "./CppUnitLite/TestHarness.h"
+#include "./CppUnitLite/Test.h"
+#include "./ad_block_client.h"
+#include "./util.h"
+
+using std::cout;
+
+TEST(ruleDefinition, basic) {
+  const char * filterText =
+    "[Adblock Plus 2.0]\n"
+    "&video_ads_\n"
+    "&videoadid=\n"
+    "&view=ad&\n"
+    "+advertorial.\n"
+    "+adverts/\n"
+    "-2/ads/\n"
+    "-2011ad_\n"
+    "-300x100ad2.\n"
+    "-ad-001-\n"
+    "-ad-180x150px.\n"
+    "-ad-200x200-\n"
+    "! comment here";
+
+  const char * currentPageDomain = "slashdot.org";
+  const char * urlToCheck = "http://www.brianbondy.com?c=a&view=ad&b=2";
+
+  AdBlockClient client;
+  client.parse(filterText, true);
+
+  Filter none;
+  Filter *matchingFilter = &none;
+  Filter exceptionFilter;
+  Filter *matchingExceptionFilter = &exceptionFilter;
+
+  CHECK(client.findMatchingFilters(urlToCheck, FONoFilterOption,
+    currentPageDomain, &matchingFilter, &matchingExceptionFilter));
+  CHECK(matchingFilter);
+  CHECK(strcmp(matchingFilter->data, "&view=ad&") == 0);
+  CHECK(matchingExceptionFilter == nullptr);
+  CHECK(strcmp(matchingFilter->ruleDefinition, "&view=ad&") == 0);
+}
+
+TEST(ruleDefinitionEmptyByDefault, basic) {
+  AdBlockClient client;
+  client.parse(
+    "-google-analytics.$image,script,xmlhttprequest\n"
+    ".net/ad\n",
+    false);
+  const char * urlToCheck =
+    "https://www.scrumpoker.online/js/angular-google-analytics.js";
+  const char * currentPageDomain = "slashdot.org";
+
+  Filter none;
+  Filter *matchingFilter = &none;
+  Filter exceptionFilter;
+  Filter *matchingExceptionFilter = &exceptionFilter;
+
+  // Since "false" was passed in as the second argument to `parse`,
+  // then no information about the original filters should be retained.
+  CHECK(client.findMatchingFilters(urlToCheck, FOScript, currentPageDomain,
+    &matchingFilter, &matchingExceptionFilter));
+  CHECK(matchingFilter);
+  CHECK(strcmp(matchingFilter->data, "-google-analytics.") == 0);
+  CHECK(matchingExceptionFilter == nullptr);
+  CHECK(matchingFilter->ruleDefinition == nullptr);
+}
+
+// Test to see if we can parse and restore lines correctly, when there is white
+// space at the start of the line.
+TEST(ruleDefinitionLeadingWhitespace, basic) {
+  const char * filterText = "\n"
+    "    [Adblock Plus 2.0]\n"
+    "    &video_ads_\n"
+    "    &videoadid=\n"
+    "    &view=ad&\n"
+    "    ! comment here\n"
+    "    ";
+
+  const char * currentPageDomain = "slashdot.org";
+  const char * urlToCheck = "http://www.brianbondy.com?c=a&view=ad&b=2";
+
+  AdBlockClient client;
+  client.parse(filterText, true);
+
+  Filter none;
+  Filter *matchingFilter = &none;
+  Filter exceptionFilter;
+  Filter *matchingExceptionFilter = &exceptionFilter;
+
+  CHECK(client.findMatchingFilters(urlToCheck, FONoFilterOption,
+    currentPageDomain, &matchingFilter, &matchingExceptionFilter));
+  CHECK(matchingFilter);
+  CHECK(strcmp(matchingFilter->data, "&view=ad&") == 0);
+  CHECK(matchingExceptionFilter == nullptr);
+  CHECK(strcmp(matchingFilter->ruleDefinition, "&view=ad&") == 0);
+}
+
+
+// Testing returning the original filter text
+TEST(ruleDefinitionWithOptions, basic) {
+  AdBlockClient client;
+  client.parse(
+    "-google-analytics.$image,script,xmlhttprequest\n"
+    ".net/ad\n",
+    true);
+  const char * urlToCheck =
+     "https://www.scrumpoker.online/js/angular-google-analytics.js";
+  const char * currentPageDomain = "slashdot.org";
+
+  Filter none;
+  Filter *matchingFilter = &none;
+  Filter exceptionFilter;
+  Filter *matchingExceptionFilter = &exceptionFilter;
+
+  // The matching filter (matchingFilter->data) should match the
+  // filter rule itself, while the matchingFilter->ruleDefinition
+  // property should include the entire text of the defining
+  // rule, including the type and domain options.
+  CHECK(client.findMatchingFilters(urlToCheck, FOScript, currentPageDomain,
+    &matchingFilter, &matchingExceptionFilter));
+  CHECK(matchingFilter);
+  CHECK(strcmp(matchingFilter->data, "-google-analytics.") == 0);
+  CHECK(matchingExceptionFilter == nullptr);
+  CHECK(
+    strcmp(
+      matchingFilter->ruleDefinition,
+      "-google-analytics.$image,script,xmlhttprequest"
+    ) == 0
+  );
+}


### PR DESCRIPTION
added a bool flag to `AdBlockClient.prototype.parse` to control whether this data should be preserved (since otherwise the text of ~ the entire filter list would be preserved in the uncommon case of wanting to use `findMatchingFilters`).

If `true`, then the return value of `findMatchingFilters` will have `matchingOrigRule` and `matchingExceptionOrigRule` properties that have the original filter rule text.  If `false`, then the `matchingOrigRule` and `matchingExceptionOrigRule` properties are `undefined`