### PR TITLE
Refactor filter_list slightly to appease Chromium style checker plugin

### DIFF
--- a/brave/BUILD.gn
+++ b/brave/BUILD.gn
@@ -13,6 +13,8 @@ source_set("ad-block") {
     "../cosmetic_filter.h",
     "../filter.cc",
     "../filter.h",
+    "../filter_list.cc",
+    "../filter_list.h",
   ]
 
   deps = [

--- a/filter_list.cc
+++ b/filter_list.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2015 Brian R. Bondy. Distributed under the MPL2 license.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <string>
+#include <vector>
+
+#include "./filter_list.h"
+
+FilterList::FilterList(const std::string& uuid,
+                       const std::string& url,
+                       const std::string& title,
+                       const std::vector<std::string>& langs,
+                       const std::string& support_url)
+    : uuid(uuid),
+      url(url),
+      title(title),
+      langs(langs),
+      support_url(support_url) {}
+
+FilterList::FilterList(const FilterList& other) = default;
+
+FilterList::~FilterList() {
+}

--- a/filter_list.h
+++ b/filter_list.h
@@ -11,20 +11,19 @@
 
 class FilterList {
  public:
-    FilterList(const std::string &uuid,
-      const std::string &url,
-      const std::string &title,
-      const std::vector<std::string> &langs,
-      const std::string &support_url) :
-        uuid(uuid), url(url), title(title),
-        langs(langs), support_url(support_url) {
-    }
+  FilterList(const std::string& uuid,
+             const std::string& url,
+             const std::string& title,
+             const std::vector<std::string>& langs,
+             const std::string& support_url);
+  FilterList(const FilterList& other);
+  ~FilterList();
 
-    const std::string uuid;
-    const std::string url;
-    const std::string title;
-    const std::vector<std::string> langs;
-    const std::string support_url;
+  const std::string uuid;
+  const std::string url;
+  const std::string title;
+  const std::vector<std::string> langs;
+  const std::string support_url;
 };
 
 #endif  // FILTER_LIST_H_


### PR DESCRIPTION
The Chromium Style Checker plugin was complaining about the complexity
of the inlined constructors when I started referencing the regional ad
block filter list on Windows.

More details here:

https://www.chromium.org/developers/coding-style/chromium-style-checker-errors