### PR TITLE
Filter out rare rules

### DIFF
--- a/ad_block_client_wrap.cc
+++ b/ad_block_client_wrap.cc
@@ -84,10 +84,10 @@ void GenerateManifestFile(const std::string &name,
   std::ofstream outFile(filename);
   if (outFile.is_open()) {
     outFile << "{" << std::endl;
-    outFile << "  \"description\": \"Brave Ad Block Updater extension\"," << std::endl;
+    outFile << "  \"description\": \"Brave Ad Block Updater extension\"," << std::endl; // NOLINT
     outFile << "  \"key\": \"" << base64_public_key << "\"," << std::endl;
     outFile << "  \"manifest_version\": 2," << std::endl;
-    outFile << "  \"name\": \"Brave Ad Block Updater (" << name << ")\"," << std::endl;
+    outFile << "  \"name\": \"Brave Ad Block Updater (" << name << ")\"," << std::endl; // NOLINT
     outFile << "  \"version\": \"0.0.0\"" << std::endl;
     outFile << "}" << std::endl;
   }
@@ -544,7 +544,7 @@ void AdBlockClientWrap::GenerateRegionalManifestFiles(
   String::Utf8Value str(args[0]->ToString());
   const char * dir = *str;
   for (auto& entry : region_lists) {
-    std::string filename = dir + std::string("/") + entry.uuid + std::string("-manifest.json");
+    std::string filename = dir + std::string("/") + entry.uuid + std::string("-manifest.json"); // NOLINT
     GenerateManifestFile(entry.title, entry.base64_public_key, filename);
   }
 }

--- a/lib/filtering.js
+++ b/lib/filtering.js
@@ -25,7 +25,7 @@ let rareFilterRulesSet
  * This function depends on rareFilterRulesSet being set, and so should not
  * be called directly.  It should ony be called through filterRareRulesPromise.
  *
- * @param aRule {string} - a ABP fitler rule
+ * @param aRule {string} - a ABP filter rule
  *
  * @return boolean - false if the rule is a known rarely used rule, and so
  *                   should be discarded from further consideration.  Otherwise,
@@ -36,7 +36,7 @@ const _filterRareRulesFn = aRule => rareFilterRulesSet.has(aRule) === false
 /**
  * Sets the URL that rare rule data should be fetched from.
  *
- * By default this is a publically available, regularly updated URL
+ * By default this is a publicly available, regularly updated URL
  * maintained by Brave.  This function can be used to change this value
  * for testing purposes.
  *
@@ -48,13 +48,13 @@ const setRareRuleDataUrl = aUrl => {
 }
 
 /**
- * Sets the ABP rules that should be treated as "infreqently" observed.
+ * Sets the ABP rules that should be treated as "infrequently" observed.
  *
  * This only should be done in unit-test like situations.  Setting this
  * value as anything other than undefined will cause the provided
  * string to be treated as the list of rare ABP rules.
  *
- * @param rareRules {string} - A new-line seperated set of ABP filter rules
+ * @param rareRules {string} - A new-line separated set of ABP filter rules
  *                             that should be treated as rare.
  */
 const setRareRuleData = rareRules => {
@@ -62,14 +62,44 @@ const setRareRuleData = rareRules => {
 }
 
 /**
+ * Fetches a set of rare rules that should not be pushed down to Brave clients.
+ *
+ * @param {?string} url - optional URL to fetch the rare rule list from.  If
+ *                        not provided, then the rare rules are fetched from
+ *                        this module's `rareRulesUrl`.
+ *
+ * @return {Promise} - A promise that either resolves to a set of strings,
+ *                     each depicting a unique, rarely applied easylist
+ *                     rule, or rejects with a description of the HTTP error
+ *                     that occurred when when fetching the rare rules.
+ */
+const fetchRareRulesSetPromise = url => {
+  const urlToFetch = url || rareRulesUrl
+  return new Promise((resolve, reject) => {
+    request.get(urlToFetch, (error, response, body) => {
+      if (error) {
+        reject(`Request error: ${error}`)
+        return
+      }
+      if (response.statusCode !== 200) {
+        reject(`Error status code ${response.statusCode} returned for URL: ${urlToFetch}`)
+        return
+      }
+
+      resolve(new Set(body.trim().split('\n')))
+    })
+  })
+}
+
+/**
  * Filter-like function that removes rarely used ABP rules from a filter text
  *
- * @param rulesText {string} - a string, containing new-line seperated ABP
+ * @param rulesText {string} - a string, containing new-line separated ABP
  *                             filter rules.  This will match something like
  *                             whats returned from easylist directly.
  *
  * @return Promise - A promise that either resolves to the filtered set of
- *                   fequently-used ABP rules, or rejects with a description
+ *                   frequently-used ABP rules, or rejects with a description
  *                   of the error encountered when fetching the unused
  *                   filters data.
  */
@@ -81,21 +111,13 @@ const filterRareRulesPromise = rulesText => {
     }
 
     console.log(`Fetching unused rules data from ${rareRulesUrl}...`)
-    request.get(rareRulesUrl, (error, response, body) => {
-      if (error) {
-        console.error(`Request error: ${error}`)
-        reject()
-        return
-      }
-      if (response.statusCode !== 200) {
-        console.error(`Error status code ${response.statusCode} returned for URL: ${rareRulesUrl}`)
-        reject()
-        return
-      }
-
-      rareFilterRulesSet = new Set(body.trim().split('\n'))
-      resolve(rulesText.split('\n').filter(_filterRareRulesFn).join('\n'))
-    })
+    fetchRareRulesSetPromise()
+      .then(fetchedRareRulesSet => {
+        const rareRulesArray = Array.from(fetchedRareRulesSet)
+        const filteredRareRulesArray = rareRulesArray.filter(_filterRareRulesFn)
+        rareFilterRulesSet = new Set(filteredRareRulesArray)
+        resolve(filteredRareRulesArray.join('\n'))
+      })
   })
 }
 
@@ -121,17 +143,22 @@ const mapRule = (rule) => rule
  * Given a list of inputs returns a filtered list of rules that should be used.
  *
  * @param input {string} - ABP filter syntax to filter
- * @return A better filter list
+ *
+ * @return {Promise} A promise that resolves with a string, describing a
+ *                   a filtered set of rules, with each rule separated by
+ *                   a newline, or that rejects with a string describing
+ *                   the encountered error.
  */
-const sanitizeABPInput = (input, filterPredicate = I) =>
-  input.split('\n')
-    .filter((rule) =>
-      filterPredicateWithPossibleLogging(rule, filterPredicate))
+const sanitizeABPInputPromise = (input, filterPredicate = I) => {
+  const filteredRulesText = input.split('\n')
+    .filter(rule => filterPredicateWithPossibleLogging(rule, filterPredicate))
     .map(mapRule)
     .join('\n')
+  return filterRareRulesPromise(filteredRulesText)
+}
 
 module.exports = {
-  sanitizeABPInput,
+  sanitizeABPInputPromise,
   filterRareRulesPromise,
   setRareRuleData,
   setRareRuleDataUrl

--- a/lib/filtering.js
+++ b/lib/filtering.js
@@ -2,6 +2,103 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const request = require('request')
+
+/**
+ * URL that rare-filter rule data should be fetched from.
+ *
+ * @type string
+ */
+let rareRulesUrl = 'https://s3.amazonaws.com/com.brave.research.public/brave-unused-filters.txt'
+
+/**
+ * A set depicting ABP filter rules that are in tracked lists, but rarely
+ *
+ * used online.
+ * @type undefined|Set
+ */
+let rareFilterRulesSet
+
+/**
+ * Array.prototype.filter style function for removing rarely used filter rules.
+ *
+ * This function depends on rareFilterRulesSet being set, and so should not
+ * be called directly.  It should ony be called through filterRareRulesPromise.
+ *
+ * @param aRule {string} - a ABP fitler rule
+ *
+ * @return boolean - false if the rule is a known rarely used rule, and so
+ *                   should be discarded from further consideration.  Otherwise,
+ *                   true.
+ */
+const _filterRareRulesFn = aRule => rareFilterRulesSet.has(aRule) === false
+
+/**
+ * Sets the URL that rare rule data should be fetched from.
+ *
+ * By default this is a publically available, regularly updated URL
+ * maintained by Brave.  This function can be used to change this value
+ * for testing purposes.
+ *
+ * @param aUrl {string} - the URL that should be fetched from when
+ *                        determining which filter rules are rarely applied.
+ */
+const setRareRuleDataUrl = aUrl => {
+  rareRulesUrl = aUrl
+}
+
+/**
+ * Sets the ABP rules that should be treated as "infreqently" observed.
+ *
+ * This only should be done in unit-test like situations.  Setting this
+ * value as anything other than undefined will cause the provided
+ * string to be treated as the list of rare ABP rules.
+ *
+ * @param rareRules {string} - A new-line seperated set of ABP filter rules
+ *                             that should be treated as rare.
+ */
+const setRareRuleData = rareRules => {
+  rareFilterRulesSet = new Set(rareRules.split('\n'))
+}
+
+/**
+ * Filter-like function that removes rarely used ABP rules from a filter text
+ *
+ * @param rulesText {string} - a string, containing new-line seperated ABP
+ *                             filter rules.  This will match something like
+ *                             whats returned from easylist directly.
+ *
+ * @return Promise - A promise that either resolves to the filtered set of
+ *                   fequently-used ABP rules, or rejects with a description
+ *                   of the error encountered when fetching the unused
+ *                   filters data.
+ */
+const filterRareRulesPromise = rulesText => {
+  return new Promise((resolve, reject) => {
+    if (rareFilterRulesSet !== undefined) {
+      resolve(rulesText.split('\n').filter(_filterRareRulesFn).join('\n'))
+      return
+    }
+
+    console.log(`Fetching unused rules data from ${rareRulesUrl}...`)
+    request.get(rareRulesUrl, (error, response, body) => {
+      if (error) {
+        console.error(`Request error: ${error}`)
+        reject()
+        return
+      }
+      if (response.statusCode !== 200) {
+        console.error(`Error status code ${response.statusCode} returned for URL: ${rareRulesUrl}`)
+        reject()
+        return
+      }
+
+      rareFilterRulesSet = new Set(body.trim().split('\n'))
+      resolve(rulesText.split('\n').filter(_filterRareRulesFn).join('\n'))
+    })
+  })
+}
+
 const I = (x) => x
 
 /**
@@ -34,5 +131,8 @@ const sanitizeABPInput = (input, filterPredicate = I) =>
     .join('\n')
 
 module.exports = {
-  sanitizeABPInput
+  sanitizeABPInput,
+  filterRareRulesPromise,
+  setRareRuleData,
+  setRareRuleDataUrl
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const request = require('request')
-const {sanitizeABPInput, filterRareRulesPromise} = require('./filtering')
+const {sanitizeABPInputPromise} = require('./filtering')
 const fs = require('fs')
 const {AdBlockClient, adBlockLists} = require('..')
 
@@ -59,8 +59,7 @@ const getSingleListDataFromSingleURL = (listURL, filter) => {
       if (filter) {
         body = filter(body)
       }
-      body = sanitizeABPInput(body)
-      filterRareRulesPromise(body)
+      sanitizeABPInputPromise(body)
         .then(resolve)
     })
   })
@@ -81,8 +80,10 @@ const makeAdBlockClientFromListURL = (listURL, filter) => {
       })
       Promise.all(requestPromises).then((results) => {
         let body = results.join('\n')
-        body = sanitizeABPInput(body)
-        resolve(makeAdBlockClientFromString(body))
+        sanitizeABPInputPromise(body)
+          .then(filteredBody => {
+            resolve(makeAdBlockClientFromString(filteredBody))
+          })
       }).catch((error) => {
         console.error(`getSingleListDataFromSingleURL error: ${error}`)
         reject()
@@ -90,8 +91,10 @@ const makeAdBlockClientFromListURL = (listURL, filter) => {
     } else {
       console.log(`${listURL}...`)
       getSingleListDataFromSingleURL(listURL, filter).then((listData) => {
-        const body = sanitizeABPInput(listData)
-        resolve(makeAdBlockClientFromString(body))
+        sanitizeABPInputPromise(listData)
+          .then(filteredBody => {
+            resolve(makeAdBlockClientFromString(filteredBody))
+          })
       }).catch((error) => {
         console.error(`getSingleListDataFromSingleURL error: ${error}`)
         reject()
@@ -152,8 +155,7 @@ const getListBufferFromURL = (listURL, filter) => {
       if (filter) {
         body = filter(body)
       }
-      body = sanitizeABPInput(body)
-      filterRareRulesPromise(body)
+      sanitizeABPInputPromise(body)
         .then(resolve)
     })
   })

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const request = require('request')
-const {sanitizeABPInput} = require('./filtering')
+const {sanitizeABPInput, filterRareRulesPromise} = require('./filtering')
 const fs = require('fs')
 const {AdBlockClient, adBlockLists} = require('..')
 
@@ -60,7 +60,8 @@ const getSingleListDataFromSingleURL = (listURL, filter) => {
         body = filter(body)
       }
       body = sanitizeABPInput(body)
-      resolve(body)
+      filterRareRulesPromise(body)
+        .then(resolve)
     })
   })
 }
@@ -152,7 +153,8 @@ const getListBufferFromURL = (listURL, filter) => {
         body = filter(body)
       }
       body = sanitizeABPInput(body)
-      resolve(body)
+      filterRareRulesPromise(body)
+        .then(resolve)
     })
   })
 }

--- a/lists/default.h
+++ b/lists/default.h
@@ -7,9 +7,10 @@
 #define LISTS_DEFAULT_H_
 
 #include <vector>
+#include <string>
 #include "../filter_list.h"
 
-const std::string kAdBlockDefaultComponentId("cffkpbalmllkdoenhmdmpbkajipdjfam");
+const std::string kAdBlockDefaultComponentId("cffkpbalmllkdoenhmdmpbkajipdjfam"); // NOLINT
 const std::string kAdBlockDefaultBase64PublicKey =
     "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs0qzJmHSgIiw7IGFCxij"
     "1NnB5hJ5ZQ1LKW9htL4EBOaMJvmqaDs/wfq0nw/goBHWsqqkMBynRTu2Hxxirvdb"

--- a/lists/regions.h
+++ b/lists/regions.h
@@ -17,7 +17,7 @@ const std::vector<FilterList> region_lists = {
     {"ar"},
     "https://forums.lanik.us/viewforum.php?f=98",
     "gpgegghiabhggiplapgdfnfcmodkccji",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnbHn298ZQjKnWlC6NgkvS3Dr7Neu87d1h8s3b9GTlc1QNDWiYgY5IfWVq/1FBw2nUFE/v8fNJg8quq8Z2nS8dYiJDVSGRggiCooa0OTCARL0BsGxHZO6s2QROYIcxPVnzISqg5zRIBc+8npE68uVUrDR6q/KdJ8siL2hrR/NybPp+uTK44lHOEIBFm8ih1rC6z+Y5dHfhax0CuL6wlWwVNcFe1macYEcOXShwkUOADh6rEBQZKJmv474xJutmB8nIpGq7C2Hn2HNNyfA6tYmhVlsaeEC44phGITKDai03wFsWWkHQPEU5HwFzKQGIBFwudyO8iigO5m+d3XSzgSZtQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnbHn298ZQjKnWlC6NgkvS3Dr7Neu87d1h8s3b9GTlc1QNDWiYgY5IfWVq/1FBw2nUFE/v8fNJg8quq8Z2nS8dYiJDVSGRggiCooa0OTCARL0BsGxHZO6s2QROYIcxPVnzISqg5zRIBc+8npE68uVUrDR6q/KdJ8siL2hrR/NybPp+uTK44lHOEIBFm8ih1rC6z+Y5dHfhax0CuL6wlWwVNcFe1macYEcOXShwkUOADh6rEBQZKJmv474xJutmB8nIpGq7C2Hn2HNNyfA6tYmhVlsaeEC44phGITKDai03wFsWWkHQPEU5HwFzKQGIBFwudyO8iigO5m+d3XSzgSZtQIDAQAB" // NOLINT
   }), FilterList({
     "FD176DD1-F9A0-4469-B43E-B1764893DD5C",
     "http://stanev.org/abp/adblock_bg.txt",
@@ -25,7 +25,7 @@ const std::vector<FilterList> region_lists = {
     {"bg"},
     "http://stanev.org/abp/",
     "coofeapfgmpkchclgdphgpmfhmnplbpn",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoqpe6QWKketr66AW+hKSxr5qds9gxmU72N20bG/nG8wfbPUdTwEqIG3m5e37Iq1FI0gcQir5UqwZZUgkum5dWJwgCB1SOaVvlZrWZbTbATKFcePswHqAIXMfS+wzMA/Ifoky26dE4k/rs6J/zQEbeXXon/ikjGJ7GxYeHYMBz9DAPQhcUoBlh1C0O0vhvXU+kG5DO4wdIt9W/cXJtv+8OTZ6HiTJw1j0jAliFZI/jhkYB6MW57OBpBYlWJQhMbLbK5opXq6d4ELbjC1amqI1lT3j5bl0g1OpMqL4Jtz6578G79gMJfxE3hA5tL0rGU3vAmwck/jXh7uOOzqetwdBcwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoqpe6QWKketr66AW+hKSxr5qds9gxmU72N20bG/nG8wfbPUdTwEqIG3m5e37Iq1FI0gcQir5UqwZZUgkum5dWJwgCB1SOaVvlZrWZbTbATKFcePswHqAIXMfS+wzMA/Ifoky26dE4k/rs6J/zQEbeXXon/ikjGJ7GxYeHYMBz9DAPQhcUoBlh1C0O0vhvXU+kG5DO4wdIt9W/cXJtv+8OTZ6HiTJw1j0jAliFZI/jhkYB6MW57OBpBYlWJQhMbLbK5opXq6d4ELbjC1amqI1lT3j5bl0g1OpMqL4Jtz6578G79gMJfxE3hA5tL0rGU3vAmwck/jXh7uOOzqetwdBcwIDAQAB" // NOLINT
   }), FilterList({
     "11F62B02-9D1F-4263-A7F8-77D2B55D4594",
     "https://easylist-downloads.adblockplus.org/easylistchina.txt",
@@ -33,7 +33,7 @@ const std::vector<FilterList> region_lists = {
     {"zh"},
     "http://abpchina.org/forum/forum.php",
     "llhecljkijgcaalnbfadljdpkpbehakp",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyahWbgHuWAI7CkBdclxOlehPVVGuG8u6bPi1vs016Kbhn9GThEVIP5qzAFQLA3jRrGy5B2nncdaCnibf7BkGsNR7nyQQuXAI2FGk9qCm36ZF7FI/yjtN0S0e6LzSswOcVhTdPnVkxYY6UDuKyzVRxgbF9Yg1aT45NFpJFZKFtKHexnLiY6KlZKV6GhY1jucjo7W77xdpLaspkYbQ69UvDlSA093InAzzikuqBdKvY0FPvC6pgiefqWTMa4M1cZU9IoIiukqrpXQn1tC9PJ8CU4XKCTshaNbpX5wxY10rUl7i/WHNcXCfmCXxKbqRZ1SyH6KiiBrDpSnfKXxrQip4GwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyahWbgHuWAI7CkBdclxOlehPVVGuG8u6bPi1vs016Kbhn9GThEVIP5qzAFQLA3jRrGy5B2nncdaCnibf7BkGsNR7nyQQuXAI2FGk9qCm36ZF7FI/yjtN0S0e6LzSswOcVhTdPnVkxYY6UDuKyzVRxgbF9Yg1aT45NFpJFZKFtKHexnLiY6KlZKV6GhY1jucjo7W77xdpLaspkYbQ69UvDlSA093InAzzikuqBdKvY0FPvC6pgiefqWTMa4M1cZU9IoIiukqrpXQn1tC9PJ8CU4XKCTshaNbpX5wxY10rUl7i/WHNcXCfmCXxKbqRZ1SyH6KiiBrDpSnfKXxrQip4GwIDAQAB" // NOLINT
   }), FilterList({
     "CC98E4BA-9257-4386-A1BC-1BBF6980324F",
     "https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjx-annoyance.txt", // NOLINT
@@ -41,7 +41,7 @@ const std::vector<FilterList> region_lists = {
     {},
     "https://github.com/cjx82630/cjxlist",
     "llpoppgpcimnmhgehpipdmamalmpfbjd",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAudVtKg3tZbgealGvVzbEL3yP1YWdt6GRDreqy/b3kCce3AZ8WroL8jb6Zj/aapBRCNxBezXzij+b6QiIH/l7sn5Wf5HDs5Vnrx4fDvGRtSLpgP0cSuFGVDx71TQz4X+AnUubOeHskIlJJAT4t4cHWs9c7EAl3ShG7DtvL2qHG2TUfJFqYOMOtQd2qG5H+X9zAUFP/qRHT55gzce8h+SXCsvdK4B8XK1cdvbIykllbGPzZr/TANn9gCtMKxUfk1qFn1uYD6mzg80KJmof8MHbLon6KLMqywcqfwEwvoivxo6f5LkOUjhqDYZEQ5la3h7lFfHKz7fCE7FCww7bQ028lwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAudVtKg3tZbgealGvVzbEL3yP1YWdt6GRDreqy/b3kCce3AZ8WroL8jb6Zj/aapBRCNxBezXzij+b6QiIH/l7sn5Wf5HDs5Vnrx4fDvGRtSLpgP0cSuFGVDx71TQz4X+AnUubOeHskIlJJAT4t4cHWs9c7EAl3ShG7DtvL2qHG2TUfJFqYOMOtQd2qG5H+X9zAUFP/qRHT55gzce8h+SXCsvdK4B8XK1cdvbIykllbGPzZr/TANn9gCtMKxUfk1qFn1uYD6mzg80KJmof8MHbLon6KLMqywcqfwEwvoivxo6f5LkOUjhqDYZEQ5la3h7lFfHKz7fCE7FCww7bQ028lwIDAQAB" // NOLINT
   }), FilterList({
     "92AA0D3B-34AC-4657-9A5C-DBAD339AF8E2",
     "https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjxlist.txt",
@@ -49,7 +49,7 @@ const std::vector<FilterList> region_lists = {
     {},
     "https://github.com/cjx82630/cjxlist",
     "lgfeompbgommiobcenmodekodmdajcal",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtAMyjMBZCbqNIuO01ZFJ5iKmcNFuJHXIUqhO9s6j6XnBAfak/OOk4s9k3maXyhaynXVpYATQyRHR0OEpmsQawFgKCmVm1LB68jxJ5Hh1ZITG1UyfznYnozkjBtzdkMGKeuZFBaHo5PPueHVO7yJDHvU3UFW4vCJ01twXiH4y0qaYjL1CPr58J9U0oKxptsfwEC53WcDq6mKtAKRpyxN6vbtFJ5/li2yC0Ms+8Xe3Xv5ovniM/4vNf3Jn1w0jzgrDRcW2VhxpydsH6q7oaR2igIzJ+XG6/k0g29CJhfT85dJNF31TwqvoI+Ju6hjZrEmSHmC7gbY7gN3ak+DbUrQxjwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtAMyjMBZCbqNIuO01ZFJ5iKmcNFuJHXIUqhO9s6j6XnBAfak/OOk4s9k3maXyhaynXVpYATQyRHR0OEpmsQawFgKCmVm1LB68jxJ5Hh1ZITG1UyfznYnozkjBtzdkMGKeuZFBaHo5PPueHVO7yJDHvU3UFW4vCJ01twXiH4y0qaYjL1CPr58J9U0oKxptsfwEC53WcDq6mKtAKRpyxN6vbtFJ5/li2yC0Ms+8Xe3Xv5ovniM/4vNf3Jn1w0jzgrDRcW2VhxpydsH6q7oaR2igIzJ+XG6/k0g29CJhfT85dJNF31TwqvoI+Ju6hjZrEmSHmC7gbY7gN3ak+DbUrQxjwIDAQAB" // NOLINT
   }), FilterList({
     "7CCB6921-7FDA-4A9B-B70A-12DD0A8F08EA",
     "https://raw.githubusercontent.com/tomasko126/easylistczechandslovak/master/filters.txt", // NOLINT
@@ -57,7 +57,7 @@ const std::vector<FilterList> region_lists = {
     {"cs"},
     "https://github.com/tomasko126/easylistczechandslovak",
     "omkkefoeihpbpebhhbhmjekpnegokpbj",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuYBXbfloR5HddFlg80U8+pf5TqfFJQAf1bL4myp9KfGggwqrjuRzIkPOD8J8IvCp8tWv2f4QK9sAPHhtV6w1cnYX24lKxrQ/lHHAV6/CEcFa+2Yk7cRLKDC10H3r4FMRoCeAy/ruTjVPfIw+GuAfFYl1qYWBNxvW7XXw7cCIIYL4j82YQF6HjsWbTT+QHLCR6h66wvIyVQC9ppjJPxDaEevjt4tohEFAB1NBC+Wxt8H/P5r5ayNcLnb9Ygt75haYL8VWZOJhO/neSTyuidTFG5ox2Ruc6TXP8t0IqpVtiZUDkx1jzUakIHoKNMBc7oz3P/SQ4AanZsIliJobXFeUiQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuYBXbfloR5HddFlg80U8+pf5TqfFJQAf1bL4myp9KfGggwqrjuRzIkPOD8J8IvCp8tWv2f4QK9sAPHhtV6w1cnYX24lKxrQ/lHHAV6/CEcFa+2Yk7cRLKDC10H3r4FMRoCeAy/ruTjVPfIw+GuAfFYl1qYWBNxvW7XXw7cCIIYL4j82YQF6HjsWbTT+QHLCR6h66wvIyVQC9ppjJPxDaEevjt4tohEFAB1NBC+Wxt8H/P5r5ayNcLnb9Ygt75haYL8VWZOJhO/neSTyuidTFG5ox2Ruc6TXP8t0IqpVtiZUDkx1jzUakIHoKNMBc7oz3P/SQ4AanZsIliJobXFeUiQIDAQAB" // NOLINT
   }), FilterList({
     "E71426E7-E898-401C-A195-177945415F38",
     "https://easylist-downloads.adblockplus.org/easylistgermany.txt",
@@ -65,7 +65,7 @@ const std::vector<FilterList> region_lists = {
     {"de"},
     "https://forums.lanik.us/viewforum.php?f=90",
     "jmomcjcilfpbaaklkifaijjcnancamde",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1HeinhQW1+SS5Xkfxb1KGAdSQqcm8bTx3fg40xVwsSre6B/VKnBLgOD9mTnbBHBY4rfymxwhD7dTHf05Y7LAkAhTEFLyi09GYPBesJ7uO2EZMYuPEd6iKx1lKo/zF9eO0VrDtjz+vw9zwriHtFMJLxz2+QXH18tx/jcvRiM8mxKB64ma+mZO38zHDs+KPDNBigtXcMhjfKbk3vnl/bl/Adzibx44gEol+abEHkvItLwdaBb3vRTEFiiO8MoTJYFY8qMxwZK4aSr6Ox5yDKzCc7dy/eIarb+zfzbk7QJD+FsNuQ34h/7gMnUE+AX+SNxFpGKRRAJFHbBPr/ofHxorUQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1HeinhQW1+SS5Xkfxb1KGAdSQqcm8bTx3fg40xVwsSre6B/VKnBLgOD9mTnbBHBY4rfymxwhD7dTHf05Y7LAkAhTEFLyi09GYPBesJ7uO2EZMYuPEd6iKx1lKo/zF9eO0VrDtjz+vw9zwriHtFMJLxz2+QXH18tx/jcvRiM8mxKB64ma+mZO38zHDs+KPDNBigtXcMhjfKbk3vnl/bl/Adzibx44gEol+abEHkvItLwdaBb3vRTEFiiO8MoTJYFY8qMxwZK4aSr6Ox5yDKzCc7dy/eIarb+zfzbk7QJD+FsNuQ34h/7gMnUE+AX+SNxFpGKRRAJFHbBPr/ofHxorUQIDAQAB" // NOLINT
   }), FilterList({
     "9EF6A21C-5014-4199-95A2-A82491274203",
     "https://adblock.dk/block.csv",
@@ -73,7 +73,7 @@ const std::vector<FilterList> region_lists = {
     {"da"},
     "https://henrik.schack.dk/adblock/",
     "facajiciiepdpjnoifonbfgcnlbpbieo",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxvmMjXthrTjGl0WDrL+4qYSVao5vKPGerr2VeUiZ1o94+P0IJyZzq3d7UP2nOvhveGl15YYxYss+sD/sUkUW57XMx+H4TF5OzGCwV8nkz4VoMIfEU6CKgYmRGHV2VoMdIHG7R++jX20+GAoeBw+aBx9+AHlBouf1kvqbkutVh+Bre1cVa6YsgsPVcmhiEp7wjz2yB23f44+pBIQgWlKWn7z9e1osG4LUCGk6gavtRoNGS3TAUf1Sq9EUibFJVmBjujVoiQKD8GIFKmLM9Fxl1Q+xgG2PCCSBz5lSesHkphDpwhszedurpKbWsnsRPqbqR3GmpceKQheWL/Y56tf2gwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxvmMjXthrTjGl0WDrL+4qYSVao5vKPGerr2VeUiZ1o94+P0IJyZzq3d7UP2nOvhveGl15YYxYss+sD/sUkUW57XMx+H4TF5OzGCwV8nkz4VoMIfEU6CKgYmRGHV2VoMdIHG7R++jX20+GAoeBw+aBx9+AHlBouf1kvqbkutVh+Bre1cVa6YsgsPVcmhiEp7wjz2yB23f44+pBIQgWlKWn7z9e1osG4LUCGk6gavtRoNGS3TAUf1Sq9EUibFJVmBjujVoiQKD8GIFKmLM9Fxl1Q+xgG2PCCSBz5lSesHkphDpwhszedurpKbWsnsRPqbqR3GmpceKQheWL/Y56tf2gwIDAQAB" // NOLINT
   }), FilterList({
     "0783DBFD-B5E0-4982-9B4A-711BDDB925B7",
     "http://adblock.ee/list.php",
@@ -81,7 +81,7 @@ const std::vector<FilterList> region_lists = {
     {"et"},
     "http://adblock.ee/",
     "fnpjliiiicbbpkfihnggnmobcpppjhlj",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnrl1tavPfozqu7CmqNfVUtZfUlIitbWpFBRn+HVW0oEFUNqAwNlwHqy9QZP88wKvb5N3EJj6NAq6je4ii6nMkDn59teNzGA4m8QSkeOWT6pNm98FZA6HNHPnhnYSG2sT8tpQ8Uyh4ySrxj2ijVM0Hc01WKQ6zjkvZWOuZWllsCejRZmxGOLUUy5mtKhIfHiuleZ7AmKx46AiVFvrpvV5x8G2HKAlF/uDc6LmV0lfXcROt5RlY+kD/sQ6wKcatibpHbLoRHOJx3ac13+pvt85773af0MdrvdCYjxvqn3DJlKw9qqk/B59n+XdTmWcfC9k77Z0teoMM5EBy8G1nGbelwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnrl1tavPfozqu7CmqNfVUtZfUlIitbWpFBRn+HVW0oEFUNqAwNlwHqy9QZP88wKvb5N3EJj6NAq6je4ii6nMkDn59teNzGA4m8QSkeOWT6pNm98FZA6HNHPnhnYSG2sT8tpQ8Uyh4ySrxj2ijVM0Hc01WKQ6zjkvZWOuZWllsCejRZmxGOLUUy5mtKhIfHiuleZ7AmKx46AiVFvrpvV5x8G2HKAlF/uDc6LmV0lfXcROt5RlY+kD/sQ6wKcatibpHbLoRHOJx3ac13+pvt85773af0MdrvdCYjxvqn3DJlKw9qqk/B59n+XdTmWcfC9k77Z0teoMM5EBy8G1nGbelwIDAQAB" // NOLINT
   }), FilterList({
     "5E5C9C94-0516-45F2-9AFB-800F0EC74FCA",
     "https://raw.githubusercontent.com/liamja/Prebake/master/obtrusive.txt",
@@ -89,7 +89,7 @@ const std::vector<FilterList> region_lists = {
     {},
     "https://github.com/liamja/Prebake",
     "abeicfkepbhgindohkebelkkhnnijcaf",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsDGkXlpuILNJ/iPEsXXdw+ZVBPf7L11UkG2az6NaeumxKfOTBDivPCXz48lWG4d6jySR8n+eMOaqX8FUVc50AGnWfq/Ud7PJdkvYNEyTNjZw7yQUta3q1yfc5gVsc1IiG9s0GuZxzSWnI0zfwMIG6JNTZTdPeIL1VxnFySXwyYKr1QhkVcpiN5AYNA8jXmZmmZ716Cti+1kAlGLQSO0ABqFZhJvSMGUb+12z6BW20tc4spt8QgY6a8CFMasdoD3hz+gKo+rvQlgPGWQhWxuTgRJZQnyS3EKeJYBaaS11c3xfIqkK85VXuMt9x/3bu9NkXFpXcNwqBo9zs+gxodVSgwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsDGkXlpuILNJ/iPEsXXdw+ZVBPf7L11UkG2az6NaeumxKfOTBDivPCXz48lWG4d6jySR8n+eMOaqX8FUVc50AGnWfq/Ud7PJdkvYNEyTNjZw7yQUta3q1yfc5gVsc1IiG9s0GuZxzSWnI0zfwMIG6JNTZTdPeIL1VxnFySXwyYKr1QhkVcpiN5AYNA8jXmZmmZ716Cti+1kAlGLQSO0ABqFZhJvSMGUb+12z6BW20tc4spt8QgY6a8CFMasdoD3hz+gKo+rvQlgPGWQhWxuTgRJZQnyS3EKeJYBaaS11c3xfIqkK85VXuMt9x/3bu9NkXFpXcNwqBo9zs+gxodVSgwIDAQAB" // NOLINT
   }), FilterList({
     "1C6D8556-3400-4358-B9AD-72689D7B2C46",
     "http://adb.juvander.net/Finland_adb.txt",
@@ -97,7 +97,7 @@ const std::vector<FilterList> region_lists = {
     {"fi"},
     "http://www.juvander.fi/AdblockFinland",
     "kdcalgmhljnckmnfcboeabeepgnlaemf",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3seBXoyYSdtiqNAIaS5v9jP6Pr8xqgFnZyHknxNsC92fHyRW2nbuwMr78pWA4vPIyV6BFG5jS8k2RXEbWiOKNNsw7nWlfT4QMwkEu4uU1vqxsNDtdc1rdrc69aBegyNOQBS+W6aP1ESHp68AoalYKMHKpc+fi00sdQwYU9Y5oW9q4uRX3baAyuGZjP0xuKN3t+T1QnhbhkldP2WP0ooU/VRMhy2rYoE+W6eQRGrghJJG/wWznz5AiPD9EpPST/hoVWOKVco+12IbdILw7yGX2c65xPcLr6obVR+549QrgxU0W02XxS2lXKGc1NT2Zdl6ugh6XpW1RHVz7SjLIZgifwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3seBXoyYSdtiqNAIaS5v9jP6Pr8xqgFnZyHknxNsC92fHyRW2nbuwMr78pWA4vPIyV6BFG5jS8k2RXEbWiOKNNsw7nWlfT4QMwkEu4uU1vqxsNDtdc1rdrc69aBegyNOQBS+W6aP1ESHp68AoalYKMHKpc+fi00sdQwYU9Y5oW9q4uRX3baAyuGZjP0xuKN3t+T1QnhbhkldP2WP0ooU/VRMhy2rYoE+W6eQRGrghJJG/wWznz5AiPD9EpPST/hoVWOKVco+12IbdILw7yGX2c65xPcLr6obVR+549QrgxU0W02XxS2lXKGc1NT2Zdl6ugh6XpW1RHVz7SjLIZgifwIDAQAB" // NOLINT
   }), FilterList({
     "9852EFC4-99E4-4F2D-A915-9C3196C7A1DE",
     "https://easylist-downloads.adblockplus.org/liste_fr.txt",
@@ -105,7 +105,7 @@ const std::vector<FilterList> region_lists = {
     {"fr"},
     "https://forums.lanik.us/viewforum.php?f=91",
     "emaecjinaegfkoklcdafkiocjhoeilao",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsbqIWuMS7r2OPXCsIPbbLG1H/d3NM9uzCMscw7R9ZV3TwhygvMOpZrNp4Y4hImy2H+HE0OniCqzuOAaq7+SHXcdHwItvLKtnRmeWgdqxgEdzJ8rZMWnfi+dODTbA4QvxI6itU5of8trDFbLzFqgnEOBk8ZxtjM/M5v3UeYh+EYHSEyHnDSJKbKevlXC931xlbdca0q0Ps3Ln6w/pJFByGbOh212mD/PvwS6jIH3LYjrMVUMefKC/ywn/AAdnwM5mGirm1NflQCJQOpTjIhbRIXBlACfV/hwI1lqfKbFnyr4aPOdg3JcOZZVoyi+ko3rKG3vH9JPWEy24Ys9A3SYpTwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsbqIWuMS7r2OPXCsIPbbLG1H/d3NM9uzCMscw7R9ZV3TwhygvMOpZrNp4Y4hImy2H+HE0OniCqzuOAaq7+SHXcdHwItvLKtnRmeWgdqxgEdzJ8rZMWnfi+dODTbA4QvxI6itU5of8trDFbLzFqgnEOBk8ZxtjM/M5v3UeYh+EYHSEyHnDSJKbKevlXC931xlbdca0q0Ps3Ln6w/pJFByGbOh212mD/PvwS6jIH3LYjrMVUMefKC/ywn/AAdnwM5mGirm1NflQCJQOpTjIhbRIXBlACfV/hwI1lqfKbFnyr4aPOdg3JcOZZVoyi+ko3rKG3vH9JPWEy24Ys9A3SYpTwIDAQAB" // NOLINT
   }), FilterList({
     "6C0F4C7F-969B-48A0-897A-14583015A587",
     "https://www.void.gr/kargig/void-gr-filters.txt",
@@ -113,7 +113,7 @@ const std::vector<FilterList> region_lists = {
     {"el"},
     "https://github.com/kargig/greek-adblockplus-filter",
     "pmgkiiodjlmmpimpmphjhkodjnjfkeke",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4KGRug8Rw1WHk1BPfIdtdw7uwFijUac7jk1lb99lEfSq2uPV2bKCk8lLh/6ahlV/EjSN8mGiFfZIVTDFhuYhVuIO8iETrCZe1ChoI0F8ptHOPQXVPzKUFMpkRqAnH51vqx+3gG78A3+iGfAE+LjerP1j4Jx5jSvTkbN8l+RqKMtjaaL9qRHv3aRQtYB/shGgdxKeOR0f8E6yJ4tIRDHB72bDufN7wbnRoHCNnLkrAPtbIwpWRLKYcOxAB6QqKNCLx/UX/pWpGtyJmMQQBpxQgl3BT8daNp0h4Soc6VPZA9wEIQ5/a/8UpsBT9rwJGj5WdSBPSR8D54aULATPxsienQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4KGRug8Rw1WHk1BPfIdtdw7uwFijUac7jk1lb99lEfSq2uPV2bKCk8lLh/6ahlV/EjSN8mGiFfZIVTDFhuYhVuIO8iETrCZe1ChoI0F8ptHOPQXVPzKUFMpkRqAnH51vqx+3gG78A3+iGfAE+LjerP1j4Jx5jSvTkbN8l+RqKMtjaaL9qRHv3aRQtYB/shGgdxKeOR0f8E6yJ4tIRDHB72bDufN7wbnRoHCNnLkrAPtbIwpWRLKYcOxAB6QqKNCLx/UX/pWpGtyJmMQQBpxQgl3BT8daNp0h4Soc6VPZA9wEIQ5/a/8UpsBT9rwJGj5WdSBPSR8D54aULATPxsienQIDAQAB" // NOLINT
   }), FilterList({
     "EDEEE15A-6FA9-4FAC-8CA8-3565508EAAC3",
     "https://raw.githubusercontent.com/szpeter80/hufilter/master/hufilter.txt",
@@ -121,7 +121,7 @@ const std::vector<FilterList> region_lists = {
     {"hu"},
     "https://github.com/szpeter80/hufilter",
     "gemncmbgjgcjjepjkindgdhdilnaanlc",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4HNXDsDBPP4b/irxacZMYnaPjNMXS31e11nsFBvN9lFOkuwF3bEk9uEk0fDzocF6GSpXbUE0HVTqfKTTnZfvG9m+C3nT8j6N7BB/wST72s0zXCjSlLWJPGmFnFb/EDkFAGmA9FU4C+j28Obehd94OC9pSqu8DYK4LbMWPmk2fgpO9N3ZV/5Y2Ni69WKJwT72prSMzyVVEAYluCYPQWY93g6dJ9RBtwnHCmdK5TG/bN2q6f50Cw/aJSv8nshSdp+KJK6yi6fBOxF5Xb0Bj+xZGC4K4SW9JjElswaGJi2PX5I11w7xC24jNaW6BUHcJ6IXudIVmBFQxWWxkMVwfgqNlwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4HNXDsDBPP4b/irxacZMYnaPjNMXS31e11nsFBvN9lFOkuwF3bEk9uEk0fDzocF6GSpXbUE0HVTqfKTTnZfvG9m+C3nT8j6N7BB/wST72s0zXCjSlLWJPGmFnFb/EDkFAGmA9FU4C+j28Obehd94OC9pSqu8DYK4LbMWPmk2fgpO9N3ZV/5Y2Ni69WKJwT72prSMzyVVEAYluCYPQWY93g6dJ9RBtwnHCmdK5TG/bN2q6f50Cw/aJSv8nshSdp+KJK6yi6fBOxF5Xb0Bj+xZGC4K4SW9JjElswaGJi2PX5I11w7xC24jNaW6BUHcJ6IXudIVmBFQxWWxkMVwfgqNlwIDAQAB" // NOLINT
   }), FilterList({
     "93123971-5AE6-47BA-93EA-BE1E4682E2B6",
     "https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt", //NOLINT
@@ -129,7 +129,7 @@ const std::vector<FilterList> region_lists = {
     {"id"},
     "https://github.com/heradhis/indonesianadblockrules",
     "egooomckhdgnfbpofhkbhbkiejaihdll",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAptA5jVa5JkYI2jt905om4OLSHGahwgS7tu7GG0sk1YNafOo4ajKrN96Kxj0fgwGrJPhU1UiTDmrgLTZSbuC3hAscbfhuakVNo1pyFfSAVoLWSrOq5l4k6zZK+y1ahxdyJvlbz06RWE6OhIqExxGqLyMjEknkPGxBVO0cKcYHiGYUxvVPxQOg+9fGieXMlSGs/L7Mty1oJOoZ4JcPIFeSvQ5ax48E7l+yAW6psNpPqRAZ5fm7hhZXjd5+3cfXXIMStgX3X0MUHjx2KpYlv3NxMjaZQOAZiuZ3W/H7VWnV7V/ScJ9Eb+e6iG4XS15f7vFQu4zPy4UTYOl6gXnIGWGmsQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAptA5jVa5JkYI2jt905om4OLSHGahwgS7tu7GG0sk1YNafOo4ajKrN96Kxj0fgwGrJPhU1UiTDmrgLTZSbuC3hAscbfhuakVNo1pyFfSAVoLWSrOq5l4k6zZK+y1ahxdyJvlbz06RWE6OhIqExxGqLyMjEknkPGxBVO0cKcYHiGYUxvVPxQOg+9fGieXMlSGs/L7Mty1oJOoZ4JcPIFeSvQ5ax48E7l+yAW6psNpPqRAZ5fm7hhZXjd5+3cfXXIMStgX3X0MUHjx2KpYlv3NxMjaZQOAZiuZ3W/H7VWnV7V/ScJ9Eb+e6iG4XS15f7vFQu4zPy4UTYOl6gXnIGWGmsQIDAQAB" // NOLINT
   }), FilterList({
     "4C07DB6B-6377-4347-836D-68702CF1494A",
     "https://secure.fanboy.co.nz/fanboy-indian.txt",
@@ -137,7 +137,7 @@ const std::vector<FilterList> region_lists = {
     {"hi"},
     "https://www.fanboy.co.nz/filters.html",
     "fijddbnggnpidebfbejillgbopcikfpi",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAraHfJfoceCra3QEYhK2Njl8oUvtDOiT60o/HjpSsarfEgIgCKgqF/sUGK2PVL4c2CsF+fG+YzI4eGrJ85rXL5Z47lmP666r9lZcMVoGs2L7RT8UvsVwpyxiH868kLVxeM0NBas/jIy7jAul5/fGf0fRUF0TbSIG/tghO8nR4bloYEbSri9BWcl6ccMfAKsIalNWnP3uifjC/t7BWIkY486zq/UPXdIuJbRPWqJDTS6EZH5ZXFDkLE8tta3OrRV7n3ei2HdyTnJOVj2DSskKWwAA7fpYGVnmJouBqg++kC6YqSnaW2ElVzQIaiRigwXj4keAZzMoDbTrGh7g+LSVngwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAraHfJfoceCra3QEYhK2Njl8oUvtDOiT60o/HjpSsarfEgIgCKgqF/sUGK2PVL4c2CsF+fG+YzI4eGrJ85rXL5Z47lmP666r9lZcMVoGs2L7RT8UvsVwpyxiH868kLVxeM0NBas/jIy7jAul5/fGf0fRUF0TbSIG/tghO8nR4bloYEbSri9BWcl6ccMfAKsIalNWnP3uifjC/t7BWIkY486zq/UPXdIuJbRPWqJDTS6EZH5ZXFDkLE8tta3OrRV7n3ei2HdyTnJOVj2DSskKWwAA7fpYGVnmJouBqg++kC6YqSnaW2ElVzQIaiRigwXj4keAZzMoDbTrGh7g+LSVngwIDAQAB" // NOLINT
   }), FilterList({
     "C3C2F394-D7BB-4BC2-9793-E0F13B2B5971",
     "https://raw.githubusercontent.com/farrokhi/adblock-iran/master/filter.txt",
@@ -145,7 +145,7 @@ const std::vector<FilterList> region_lists = {
     {"fa"},
     "https://github.com/farrokhi/adblock-iran",
     "dbcccdegkijbppmeaihneimbghfghkdl",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm3AZE2ne7R55X2j6RxAQHAZKl1hNPgwLOFsYpfAJ6m0uXmKJspguWxatJ9jDBbYLmtXnwX2WORILq1+r4kFtTcN8GNYe7/7o5yDLucI/W9d2vCjmEg95v50MzVQZSwd2gNZVZtL1s0S6pBwX0zI+6kHIFr2xqGV/FNE8L75f30rriQ0xKmenI1OWjyn8gNqIp4mKZW6XxkMRRS9+e0ynDi4ysQA9Ub5YHJxm0t62eqTmIyemgRhP6Rdbi0+GXbqFPjDfC26rtD3wy5f3aYL1V+2ADpdDyCeNlwCH7+vC7LWujqNTgK8wVJ4eH5VbUKC1e9cm/T57OsHJMDC5fbUuswIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm3AZE2ne7R55X2j6RxAQHAZKl1hNPgwLOFsYpfAJ6m0uXmKJspguWxatJ9jDBbYLmtXnwX2WORILq1+r4kFtTcN8GNYe7/7o5yDLucI/W9d2vCjmEg95v50MzVQZSwd2gNZVZtL1s0S6pBwX0zI+6kHIFr2xqGV/FNE8L75f30rriQ0xKmenI1OWjyn8gNqIp4mKZW6XxkMRRS9+e0ynDi4ysQA9Ub5YHJxm0t62eqTmIyemgRhP6Rdbi0+GXbqFPjDfC26rtD3wy5f3aYL1V+2ADpdDyCeNlwCH7+vC7LWujqNTgK8wVJ4eH5VbUKC1e9cm/T57OsHJMDC5fbUuswIDAQAB" // NOLINT
   }), FilterList({
     "48796273-E783-431E-B864-44D3DCEA66DC",
     "http://adblock.gardar.net/is.abp.txt",
@@ -153,7 +153,7 @@ const std::vector<FilterList> region_lists = {
     {"is"},
     "http://adblock.gardar.net/",
     "njhlaafgablgnekjaodhgbaomabjibaf",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqSwaNKhg90HCheaJu3sHocbZUjXDs90I0OmijNkDeS291wUjvXAm5YqhNE8aZmPSMVZBjBCwKXrrtTOkMA1b1uBqJ2P83fCZsgNZWbGTD8MorMrU6vyqkWCqLRc+bTTUgzAd55ckUJ/M+HVnjo6QfqUuB3kVzjpwJorQQZUYOLcgDY/Q5/tbrXI5+OGVxAb21pmnk8JHXNNWB2NvpA2o3p0ke/7WEoUH24l91ndOkXkN87eO8rSysl07Eq7gshbednYYiCxRPjuX0aPqbXMYNWXa5NdvIXFJcD2xV/l/QvXRYl+7Ca1igSXaiKc5eJyKSRqY4lf2vG0XCH6VZVxZuQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqSwaNKhg90HCheaJu3sHocbZUjXDs90I0OmijNkDeS291wUjvXAm5YqhNE8aZmPSMVZBjBCwKXrrtTOkMA1b1uBqJ2P83fCZsgNZWbGTD8MorMrU6vyqkWCqLRc+bTTUgzAd55ckUJ/M+HVnjo6QfqUuB3kVzjpwJorQQZUYOLcgDY/Q5/tbrXI5+OGVxAb21pmnk8JHXNNWB2NvpA2o3p0ke/7WEoUH24l91ndOkXkN87eO8rSysl07Eq7gshbednYYiCxRPjuX0aPqbXMYNWXa5NdvIXFJcD2xV/l/QvXRYl+7Ca1igSXaiKc5eJyKSRqY4lf2vG0XCH6VZVxZuQIDAQAB" // NOLINT
   }), FilterList({
     "85F65E06-D7DA-4144-B6A5-E1AA965D1E47",
     "https://raw.githubusercontent.com/easylist/EasyListHebrew/master/EasyListHebrew.txt", // NOLINT
@@ -161,7 +161,7 @@ const std::vector<FilterList> region_lists = {
     {"he"},
     "https://github.com/easylist/EasyListHebrew",
     "hjeidaaocognlgpdkfeenmiefipcffbo",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoUnmZ/fnWAGhAywLBs5IX0OMxK6LOwtjljcwEkt8QD7ZKBekxq+MDrUuRPzav3ky9IyREhXe9F4UWBKPDD8ZQXZ57WQAAMAp3IxbgdAsTqqTEEReUVx+pzjl8lxdp7xEG2gpuM5wq7bjn4zJ3kcdj3vx7bec/YbYf4fV0brQPWghKf2sh3mHXOVh68wEFXYBvcWkGXfuBoRbB9WLflqZYRk3GrLllwBLn1Ag6iuKucvoyv7N23qXKIjqAhyKPmHx4l9w/v2c1pc3NB1af2xvtRWaQp19N98QouFFx5MwAI9+jR77Eox6QvRwA+L9CFkYlDTvT/aS3q+Zb1QH/8AE4QIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoUnmZ/fnWAGhAywLBs5IX0OMxK6LOwtjljcwEkt8QD7ZKBekxq+MDrUuRPzav3ky9IyREhXe9F4UWBKPDD8ZQXZ57WQAAMAp3IxbgdAsTqqTEEReUVx+pzjl8lxdp7xEG2gpuM5wq7bjn4zJ3kcdj3vx7bec/YbYf4fV0brQPWghKf2sh3mHXOVh68wEFXYBvcWkGXfuBoRbB9WLflqZYRk3GrLllwBLn1Ag6iuKucvoyv7N23qXKIjqAhyKPmHx4l9w/v2c1pc3NB1af2xvtRWaQp19N98QouFFx5MwAI9+jR77Eox6QvRwA+L9CFkYlDTvT/aS3q+Zb1QH/8AE4QIDAQAB" // NOLINT
   }), FilterList({
     "A0E9F361-A01F-4C0E-A52D-2977A1AD4BFB",
     "https://raw.githubusercontent.com/gioxx/xfiles/master/filtri.txt",
@@ -169,7 +169,7 @@ const std::vector<FilterList> region_lists = {
     {},
     "https://xfiles.noads.it/",
     "agfanagdjcijocanbeednbhclejcjlfo",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsorIQuFuMI5OaGYaYTu6+kZC4j3qPoWRoD7F9GS0IJC+VEk3XQ7UTsRXlrIxP9obmC7+pByP6hknBUzvKKS9I1v2voIqjUoydWOozbfoVoRhTLN3UiDnoDueXqXiv1MGLzY/ZcsxsxAlIiTcE7+/KdM6pJ72Mn/aLKU3escIJ5E5qOHJOFDLW9587JeWOzexaCOrtiZMclE0KWbUi7qB3Bz3auF6piSzoNGeI1NMwHSSAwhDOQ3UK09aqRKhyfBq6ugrrYyRAr3FWqmMBWkiTsr6SzrbQg3wcGbD+GDvoQmqVf8dH/WYG+srR6PyJdYH5mOQs6Yg+nu1gvwQ46Z74QIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsorIQuFuMI5OaGYaYTu6+kZC4j3qPoWRoD7F9GS0IJC+VEk3XQ7UTsRXlrIxP9obmC7+pByP6hknBUzvKKS9I1v2voIqjUoydWOozbfoVoRhTLN3UiDnoDueXqXiv1MGLzY/ZcsxsxAlIiTcE7+/KdM6pJ72Mn/aLKU3escIJ5E5qOHJOFDLW9587JeWOzexaCOrtiZMclE0KWbUi7qB3Bz3auF6piSzoNGeI1NMwHSSAwhDOQ3UK09aqRKhyfBq6ugrrYyRAr3FWqmMBWkiTsr6SzrbQg3wcGbD+GDvoQmqVf8dH/WYG+srR6PyJdYH5mOQs6Yg+nu1gvwQ46Z74QIDAQAB" // NOLINT
   }), FilterList({
     "AB1A661D-E946-4F29-B47F-CA3885F6A9F7",
     "https://easylist-downloads.adblockplus.org/easylistitaly.txt",
@@ -177,7 +177,7 @@ const std::vector<FilterList> region_lists = {
     {"it"},
     "https://forums.lanik.us/viewforum.php?f=96",
     "nkmllpnhpfieajahfpfmjneipnddhimi",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAurn1cJrIcCa8P7hjGex+OUHi19PRxmjJ5DuQlMAeIaKibwaQOZEPXSvD+O+xgxHZJs1o2DE8zfj6yrAmDfu9+/T0ArT2RWuopDMEfaKdeG0ylHP62WJC+KGUhCiTNmLyPxbU9AiwydVyFOam8vs4Tr+9I3lYKVeClQrtDRM34BTOAsuHRjiuIKoC0jDC2kc+BAsAbzhIdrkEDGD+qx0rCRnGL6c8xODe2PLKSkCSIsqOk44eYOkBqQd0SgmCvQjXS2XczMDNuV7DCZofErsy2iEv/2kzhkkN8GFwbRkYGN9LuK8rtekE34AvZKRHS6e/pHjUCYJb/2xv6elC+VLsJwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAurn1cJrIcCa8P7hjGex+OUHi19PRxmjJ5DuQlMAeIaKibwaQOZEPXSvD+O+xgxHZJs1o2DE8zfj6yrAmDfu9+/T0ArT2RWuopDMEfaKdeG0ylHP62WJC+KGUhCiTNmLyPxbU9AiwydVyFOam8vs4Tr+9I3lYKVeClQrtDRM34BTOAsuHRjiuIKoC0jDC2kc+BAsAbzhIdrkEDGD+qx0rCRnGL6c8xODe2PLKSkCSIsqOk44eYOkBqQd0SgmCvQjXS2XczMDNuV7DCZofErsy2iEv/2kzhkkN8GFwbRkYGN9LuK8rtekE34AvZKRHS6e/pHjUCYJb/2xv6elC+VLsJwIDAQAB" // NOLINT
   }), FilterList({
     "03F91310-9244-40FA-BCF6-DA31B832F34D",
     "https://raw.githubusercontent.com/k2jp/abp-japanese-filters/master/abpjf.txt", // NOLINT
@@ -185,7 +185,7 @@ const std::vector<FilterList> region_lists = {
     {"ja"},
     "https://github.com/k2jp/abp-japanese-filters/wiki/Support_Policy",
     "ghnjmapememheddlfgmklijahiofgkea",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsOoGwN4i751gHi1QmHMkFZCXFPseO/Q8qKOQViZI7p6THKqF1G3uHNxh8NjwKfsdcJLyZbnWx7BvDeyUw3K9hqWw4Iq6C0Ta1YEqEJFhcltV7J7aCMPJHdjZk5rpya9eXTWX1hfIYOvujPisKuwMNUmnlpaeWThihf4twu9BUn/X6+jcaqVaQ73q5TLS5vp13A9q2qSbEa79f/uUT8oKzN4S/GorQ6faS4bOl3iHuCT9abVXdy80WSut4bBERKgbc+0aJvi1dhpbCeM4DxVViM2ZccKvxSpyx4NvWj56dNKqFLvzoA4/Chz1udxifIXUHh0701s1Y4fLpY0wWP0uXQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsOoGwN4i751gHi1QmHMkFZCXFPseO/Q8qKOQViZI7p6THKqF1G3uHNxh8NjwKfsdcJLyZbnWx7BvDeyUw3K9hqWw4Iq6C0Ta1YEqEJFhcltV7J7aCMPJHdjZk5rpya9eXTWX1hfIYOvujPisKuwMNUmnlpaeWThihf4twu9BUn/X6+jcaqVaQ73q5TLS5vp13A9q2qSbEa79f/uUT8oKzN4S/GorQ6faS4bOl3iHuCT9abVXdy80WSut4bBERKgbc+0aJvi1dhpbCeM4DxVViM2ZccKvxSpyx4NvWj56dNKqFLvzoA4/Chz1udxifIXUHh0701s1Y4fLpY0wWP0uXQIDAQAB" // NOLINT
   }), FilterList({
     "51260D6E-28F8-4EEC-B76D-3046DADC27C9",
     "https://www.fanboy.co.nz/fanboy-korean.txt",
@@ -193,7 +193,7 @@ const std::vector<FilterList> region_lists = {
     {},
     "https://forums.lanik.us/",
     "oidcknjcjepjgfpammgdalpnjefekhge",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvCOljWKWLWfq/k/BE9gIZtI1MstmG+NcgGBGAP0R7xgaUMU5phdSbQf83Zt9ctwDRpisHWlGS6o+tk93zMIoJVj6RMQ2Zee6QPAKAGgwuCXF7A/ciI3lRyX7ts49XV8GAbasu1mBHntz+GpmOVmoiRxcDMUDDEqsSXgckCM9HkYvIyHQWyEgeulKdhQ2HoCptD2Wgmws6NzRTgQ94+DHu2o6J4MsG74h7L/cG3XB8WQNuqlpjjFIQTXftuUWDSkyR3tlmMxGN1PXAH6RZBNmwQTwdgrOAqEup82dWaO3BqoYGZdYeRaUGRc73iPdvvjZb1tvmqLdVSq7Ur1XJjJJTwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvCOljWKWLWfq/k/BE9gIZtI1MstmG+NcgGBGAP0R7xgaUMU5phdSbQf83Zt9ctwDRpisHWlGS6o+tk93zMIoJVj6RMQ2Zee6QPAKAGgwuCXF7A/ciI3lRyX7ts49XV8GAbasu1mBHntz+GpmOVmoiRxcDMUDDEqsSXgckCM9HkYvIyHQWyEgeulKdhQ2HoCptD2Wgmws6NzRTgQ94+DHu2o6J4MsG74h7L/cG3XB8WQNuqlpjjFIQTXftuUWDSkyR3tlmMxGN1PXAH6RZBNmwQTwdgrOAqEup82dWaO3BqoYGZdYeRaUGRc73iPdvvjZb1tvmqLdVSq7Ur1XJjJJTwIDAQAB" // NOLINT
   }), FilterList({
     "1E6CF01B-AFC4-47D2-AE59-3E32A1ED094F",
     "https://raw.githubusercontent.com/gfmaster/adblock-korea-contrib/master/filter.txt", // NOLINT
@@ -201,7 +201,7 @@ const std::vector<FilterList> region_lists = {
     {"ko"},
     "https://github.com/gfmaster/adblock-korea-contrib",
     "jboldinnegecjonfmaahihagfahjceoj",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArcE90V2GoQ9InvoiVqxsEnhHhdJz68yyWA+HzQBxcxitqfF5Vu6gRiKB3+W/iTJ9XNE449krWrYAjDqVt6GF8ilpieIngwCNsl7jP5RRhrcrk65as4bawSimodit+TVi7ZpIFDWoalj5RIO+rjKfwkkBHujeM7qYr/Vm1NXre57ea80TvbdoA4XgnAYHKY5VV/WstFL8FR3Do+38EyaIzKfoiRrV97BoC440oifNdi0nJQhIgULfNjUolOh9eAQKuymId+WjZeSKSckUyKMQsQ0VVDjCbm5mwRqC5D+MT9L/8sKcdXBXuGrXyaZzp3eOmc41q01VkRLXCTrx37hGQwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArcE90V2GoQ9InvoiVqxsEnhHhdJz68yyWA+HzQBxcxitqfF5Vu6gRiKB3+W/iTJ9XNE449krWrYAjDqVt6GF8ilpieIngwCNsl7jP5RRhrcrk65as4bawSimodit+TVi7ZpIFDWoalj5RIO+rjKfwkkBHujeM7qYr/Vm1NXre57ea80TvbdoA4XgnAYHKY5VV/WstFL8FR3Do+38EyaIzKfoiRrV97BoC440oifNdi0nJQhIgULfNjUolOh9eAQKuymId+WjZeSKSckUyKMQsQ0VVDjCbm5mwRqC5D+MT9L/8sKcdXBXuGrXyaZzp3eOmc41q01VkRLXCTrx37hGQwIDAQAB" // NOLINT
   }), FilterList({
     "45B3ED40-C607-454F-A623-195FDD084637",
     "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt",
@@ -209,7 +209,7 @@ const std::vector<FilterList> region_lists = {
     {"ko"},
     "https://github.com/yous/YousList",
     "djhjpnilfflibdflbkgapjfldapkjcgl",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAux80m8cYDEXwq+nMwmui6NCO9SFAdcGly5eq4uGEIQNB1R6Tr9JMqosHLZ4PnaUJqJwFfLWfmxzXj3q0DIpqqpdSq/jTYT/MvOldC+VQFO+NIjXhtysh4Z5F0BzlsQx/leMnV6yoyQjBX53n9cl3BvQK/EdbuQSDiNqX2TSVLm7hnr7Vf8m4XYRSCSJybY/1Tk3Cqgqywlkr+YN58L1/txXCQ9LJ5SxJ9I56TxqA1uT97hBmQikvnopuLh1SovDfjtCZwWwaGDD4ujW+Qaeh9dRrojS47iwG/Twu1xbb7ra8cn8BxdzsPjUSSurpPz/9sUooYOGJO44p7u77sxeTXQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAux80m8cYDEXwq+nMwmui6NCO9SFAdcGly5eq4uGEIQNB1R6Tr9JMqosHLZ4PnaUJqJwFfLWfmxzXj3q0DIpqqpdSq/jTYT/MvOldC+VQFO+NIjXhtysh4Z5F0BzlsQx/leMnV6yoyQjBX53n9cl3BvQK/EdbuQSDiNqX2TSVLm7hnr7Vf8m4XYRSCSJybY/1Tk3Cqgqywlkr+YN58L1/txXCQ9LJ5SxJ9I56TxqA1uT97hBmQikvnopuLh1SovDfjtCZwWwaGDD4ujW+Qaeh9dRrojS47iwG/Twu1xbb7ra8cn8BxdzsPjUSSurpPz/9sUooYOGJO44p7u77sxeTXQIDAQAB" // NOLINT
   }), FilterList({
     "4E8B1A63-DEBE-4B8B-AD78-3811C632B353",
     "http://margevicius.lt/easylistlithuania.txt",
@@ -217,7 +217,7 @@ const std::vector<FilterList> region_lists = {
     {"lt"},
     "http://margevicius.lt/easylist_lithuania/",
     "ekodlgldheejnlkhiceghfgdcplpeoek",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5dB+7xR4lcPQCW84V4zhLiYhAvKxgdo2/cze+C8E3+ye1AO+a1CWbdPgft36vtTm4nkDzyC3P9O/aEU8jxShKEU1DDk8YBdRnvctQ9PPvwNyeS9LCYeT5a9crE9M/Z+kaFyq0SRe5cpowOBG8x4OYTt9Y7L9whEGzZYRZlgklli1AES6e2B9XUAdHXV/wHsaf2FrdPFtDfZZEFdr60edk4f0iGppiwkaGJiOWVF1ya47NoSMl4fIF7Klw9OkfKLJHjk9YXZmXCfqxQl8FnBFe/SzbSTVCAhdaggQAwG4VmojjMrBHcQl0VJDmpoY2jFZkiO3GLmAZCYIYaN1tFA8ZwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5dB+7xR4lcPQCW84V4zhLiYhAvKxgdo2/cze+C8E3+ye1AO+a1CWbdPgft36vtTm4nkDzyC3P9O/aEU8jxShKEU1DDk8YBdRnvctQ9PPvwNyeS9LCYeT5a9crE9M/Z+kaFyq0SRe5cpowOBG8x4OYTt9Y7L9whEGzZYRZlgklli1AES6e2B9XUAdHXV/wHsaf2FrdPFtDfZZEFdr60edk4f0iGppiwkaGJiOWVF1ya47NoSMl4fIF7Klw9OkfKLJHjk9YXZmXCfqxQl8FnBFe/SzbSTVCAhdaggQAwG4VmojjMrBHcQl0VJDmpoY2jFZkiO3GLmAZCYIYaN1tFA8ZwIDAQAB" // NOLINT
   }), FilterList({
     "15B64333-BAF9-4B77-ADC8-935433CD6F4C",
     "https://notabug.org/latvian-list/adblock-latvian/raw/master/lists/latvian-list.txt", // NOLINT
@@ -225,7 +225,7 @@ const std::vector<FilterList> region_lists = {
     {"lv"},
     "https://notabug.org/latvian-list/adblock-latvian",
     "hmabmnondepbfogenlfklniehjedmicd",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAst1posKDpKt3WLU07CziowQnBKYXzH2i/sDdJfMuTcKSNQvn9dxbHVLhg8Ih7NmN6SSJTRgb2PughdVNPXqlT3/jGioDC0gN8kBrBoN2YWgIW2wdvTCPvBOfwTOhGueQY6AtE7zD/3m9v6Wfcw07Rj84Su0qI1Zadmq2pBWo5z82vOAI2yV83YGDbnyK1JaFeLToYQmj+bMEojoZ4Lk4PbFmopVh1GkeOdCKtVN2NTIy43N/w0tS0wlLxjwTyZ6RIcK3VOhQXBqcpwKpKm/4WDksTvNRLZ8e526z/nqaasM/meS22hURh6NPtIOdy6/TspTzFPiRdj2xgNfQZ9oRxwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAst1posKDpKt3WLU07CziowQnBKYXzH2i/sDdJfMuTcKSNQvn9dxbHVLhg8Ih7NmN6SSJTRgb2PughdVNPXqlT3/jGioDC0gN8kBrBoN2YWgIW2wdvTCPvBOfwTOhGueQY6AtE7zD/3m9v6Wfcw07Rj84Su0qI1Zadmq2pBWo5z82vOAI2yV83YGDbnyK1JaFeLToYQmj+bMEojoZ4Lk4PbFmopVh1GkeOdCKtVN2NTIy43N/w0tS0wlLxjwTyZ6RIcK3VOhQXBqcpwKpKm/4WDksTvNRLZ8e526z/nqaasM/meS22hURh6NPtIOdy6/TspTzFPiRdj2xgNfQZ9oRxwIDAQAB" // NOLINT
   }), FilterList({
     "9D644676-4784-4982-B94D-C9AB19098D2A",
     "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
@@ -233,7 +233,7 @@ const std::vector<FilterList> region_lists = {
     {"nl"},
     "https://forums.lanik.us/viewforum.php?f=100",
     "fbmjnabmpmfnfknjmbegjmjigmelggmf",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqqfwmNS4XOq9pWC3XSMt5WcqoKaj3lRpYAwZKTP+6DwA9pG+Zw+0iWC95riSLjqPgX+0d2cZaqjinuNn3mUMOeGdbwSIeRLE50J5J/dMmkg5YO09orZKLBjMfJG5IDgfXdZLSJtmzKC4Xj2y6KSuQ7N0Sg5f1Ecc19nFbcFazCaIhKvcoA84J7Twf2IoCDuPMsGplgZCBtFQkKeqILaVhJZeD0my6pdC2KJREbM3eRnntE44O0sbmemCfHs9BV50hVb913zGDZ379eTqg3mPjvH+VnY+7RvjVPayJP4+51zRJYKi18W7KMry3sj4ZZ3EyNKmbwlGQOzAyd/Qtj4I3wIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqqfwmNS4XOq9pWC3XSMt5WcqoKaj3lRpYAwZKTP+6DwA9pG+Zw+0iWC95riSLjqPgX+0d2cZaqjinuNn3mUMOeGdbwSIeRLE50J5J/dMmkg5YO09orZKLBjMfJG5IDgfXdZLSJtmzKC4Xj2y6KSuQ7N0Sg5f1Ecc19nFbcFazCaIhKvcoA84J7Twf2IoCDuPMsGplgZCBtFQkKeqILaVhJZeD0my6pdC2KJREbM3eRnntE44O0sbmemCfHs9BV50hVb913zGDZ379eTqg3mPjvH+VnY+7RvjVPayJP4+51zRJYKi18W7KMry3sj4ZZ3EyNKmbwlGQOzAyd/Qtj4I3wIDAQAB" // NOLINT
   }), FilterList({
     "BF9234EB-4CB7-4CED-9FCB-F1FD31B0666C",
     "https://www.certyficate.it/adblock/adblock.txt",
@@ -241,7 +241,7 @@ const std::vector<FilterList> region_lists = {
     {"pl"},
     "http://www.certyficate.it/adblock-ublock-polish-filters/",
     "paoecjnjjbclkgbempaeemcbeldldlbo",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsUqWP6CeMx79UyZ3GZ1XcBGexIgml00sB286wZ7dJsfqG7oI0EGRoqrDeRreYcOTl+HvXsRJvR1FfkKJzD5svdhR4mn4lI+FXUDCvgEZ9CFa0YfASuoTIrdZtG74Twu2ai52ZJzrQ9ike97bdwzuZo+uymw26S+5/+IQbriIYoxEbJd7EryZuo+W65LdSat/NOKKf1QnVTIOoqMrXiewRYywnmZATfDIi0uKXuQfF15lbNBkQllmPH1xlMkz2WnvSvqI4HKPAmEFJWVUkiNhGKFZkTk1+88CgGGPVsKllxLaDOD+j8Kb0+h44RxObHTF/vFkfh8FfzujFj3HtevjCQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsUqWP6CeMx79UyZ3GZ1XcBGexIgml00sB286wZ7dJsfqG7oI0EGRoqrDeRreYcOTl+HvXsRJvR1FfkKJzD5svdhR4mn4lI+FXUDCvgEZ9CFa0YfASuoTIrdZtG74Twu2ai52ZJzrQ9ike97bdwzuZo+uymw26S+5/+IQbriIYoxEbJd7EryZuo+W65LdSat/NOKKf1QnVTIOoqMrXiewRYywnmZATfDIi0uKXuQfF15lbNBkQllmPH1xlMkz2WnvSvqI4HKPAmEFJWVUkiNhGKFZkTk1+88CgGGPVsKllxLaDOD+j8Kb0+h44RxObHTF/vFkfh8FfzujFj3HtevjCQIDAQAB" // NOLINT
   }), FilterList({
     "1088D292-2369-4D40-9BDF-C7DC03C05966",
     "https://adguard.com/en/filter-rules.html?id=1",
@@ -249,7 +249,7 @@ const std::vector<FilterList> region_lists = {
     {},
     "http://forum.adguard.com/forumdisplay.php?69-%D0%A4%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D1%8B-Adguard", // NOLINT
     "dmoefgliihlcfplldbllllbofegmojne",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4p+4n2wNFQCqQBBJDsvs+oqNYGzX3cbpY7fKbCjrRVE5esJK5HZJDoUUg43pPvKrCOIQ+lF+dXpBaCNnO4O/7JeFt2IFRJnKhE3ipIBAAbFymfo5T2uWFdyh6HcK0FNyJ/7FyHnANe7vYhXJS1Fqmh6jTYkAEIbrbmxtzrDMefx3XJcVhUV3XAPlP+K3MerxudIH++4fn3X0vKob5oQQQ9ZZ1PVcW6ZdZTQwQWtaVDb6prT+ULaphRRmnZpZuRXyHMv9KC8YP3K5ou+/Yd3uxxMwKmJXD67ZoNMtS/Dtr0btQsLxiEgox5Swd4iqyLM/SMxr3LqgUIlNwn7KRbMnZwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4p+4n2wNFQCqQBBJDsvs+oqNYGzX3cbpY7fKbCjrRVE5esJK5HZJDoUUg43pPvKrCOIQ+lF+dXpBaCNnO4O/7JeFt2IFRJnKhE3ipIBAAbFymfo5T2uWFdyh6HcK0FNyJ/7FyHnANe7vYhXJS1Fqmh6jTYkAEIbrbmxtzrDMefx3XJcVhUV3XAPlP+K3MerxudIH++4fn3X0vKob5oQQQ9ZZ1PVcW6ZdZTQwQWtaVDb6prT+ULaphRRmnZpZuRXyHMv9KC8YP3K5ou+/Yd3uxxMwKmJXD67ZoNMtS/Dtr0btQsLxiEgox5Swd4iqyLM/SMxr3LqgUIlNwn7KRbMnZwIDAQAB" // NOLINT
   }), FilterList({
     "DABC6490-70E5-46DD-8BE2-358FB9A37C85",
     "https://easylist-downloads.adblockplus.org/bitblock.txt",
@@ -257,7 +257,7 @@ const std::vector<FilterList> region_lists = {
     {},
     "https://forums.lanik.us/viewforum.php?f=102",
     "fmcofgdkijoanfaodpdfjipdgnjbiolk",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApGBuuxC9pqx2s5hUd3K8zeFUtMFt9X+rSKR3elqWztjIQrbOdXSeezHvhAUdzgc+Wv79ZoRf4i4amYs3Mg3wg783BAqLvlu9r6FsUAbcgVQtt+MT3Z4ZepwvzWU0NjUd1q4O2pNEUsE8SPjmOeb3KHOF5WX7CA1uIHT5xGQsU5Uh3VTZC8FIOGjCskDAAnJGUeOowlMBGL2UvlNQLiqzPSvI9byjwxIMN5OfCmxXXr4R9m88oVK2D1gj7vfwBVJcRdV8ner4ZSuT68ncSyaQRtgI3/QyHc0J6giCRFmF0bHN/5kjFIWrHg5+uiBQN4Qt39TVCUU024Fi2RGInvTTdQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApGBuuxC9pqx2s5hUd3K8zeFUtMFt9X+rSKR3elqWztjIQrbOdXSeezHvhAUdzgc+Wv79ZoRf4i4amYs3Mg3wg783BAqLvlu9r6FsUAbcgVQtt+MT3Z4ZepwvzWU0NjUd1q4O2pNEUsE8SPjmOeb3KHOF5WX7CA1uIHT5xGQsU5Uh3VTZC8FIOGjCskDAAnJGUeOowlMBGL2UvlNQLiqzPSvI9byjwxIMN5OfCmxXXr4R9m88oVK2D1gj7vfwBVJcRdV8ner4ZSuT68ncSyaQRtgI3/QyHc0J6giCRFmF0bHN/5kjFIWrHg5+uiBQN4Qt39TVCUU024Fi2RGInvTTdQIDAQAB" // NOLINT
   }), FilterList({
     "80470EEC-970F-4F2C-BF6B-4810520C72E6",
     "https://easylist-downloads.adblockplus.org/advblock.txt",
@@ -265,7 +265,7 @@ const std::vector<FilterList> region_lists = {
     {"ru", "uk", "be"},
     "https://forums.lanik.us/viewforum.php?f=102",
     "enkheaiicpeffbfgjiklngbpkilnbkoi",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArVVgKRE868yup0HfX4+HyZmJVIk33AKivwvRRfjHRxeC+lLnRjNiY0LKS/K65J6SNLgUsZGfT5u4h4F423O/pbZl6zdfs5kOyStlmLPXhFtF/bIXIsUtdJ0R3dEz+nSg0C2L/FnE5Qr8M4thdmq/DIP1C70mj8pCnX1939hXyR0ymQkYp573O+LJ0q1L41jBqHzNKWngfBc79I2Kbt1pLluBT2X7zZVbb+1ap3Ad/VMeFDB2yurRs88cYJZOal7mgTgI/Zkuzsh2Dnql5+UNOCHinYjcOvUifGgkdsJIJxL57PxRzbriLCNjShoOV3Fpc0XYL1KSWvIVuW0bYeLmrwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArVVgKRE868yup0HfX4+HyZmJVIk33AKivwvRRfjHRxeC+lLnRjNiY0LKS/K65J6SNLgUsZGfT5u4h4F423O/pbZl6zdfs5kOyStlmLPXhFtF/bIXIsUtdJ0R3dEz+nSg0C2L/FnE5Qr8M4thdmq/DIP1C70mj8pCnX1939hXyR0ymQkYp573O+LJ0q1L41jBqHzNKWngfBc79I2Kbt1pLluBT2X7zZVbb+1ap3Ad/VMeFDB2yurRs88cYJZOal7mgTgI/Zkuzsh2Dnql5+UNOCHinYjcOvUifGgkdsJIJxL57PxRzbriLCNjShoOV3Fpc0XYL1KSWvIVuW0bYeLmrwIDAQAB" // NOLINT
   }), FilterList({
     "AE657374-1851-4DC4-892B-9212B13B15A7",
     "https://easylist-downloads.adblockplus.org/easylistspanish.txt",
@@ -273,7 +273,7 @@ const std::vector<FilterList> region_lists = {
     {"es"},
     "https://forums.lanik.us/viewforum.php?f=103",
     "pdecoifadfkklajdlmndjpkhabpklldh",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2eGyWcTM6Cpmkw6CBBxQbJCgp3Q4jyh+JR/Aqq5G+OFzxFpwlqW0dH9kNuUs30iSt1tt1gMZGYnhPKiGhtX3nV1iYg2K8k82wNqA5+ODfHxnnVn536UoC7rmjXL+mhpymxgkjGCQ+1HVmnCcSC9mxTPy65ihor+YZcRRPo0IhjQTx3NgdpzkGYvpQVjwnw3a5FpRBCbbp3X2x3EGV3DcjvT6DvvxSU/mAUPlXISo9OFHYUpADilqAevXQIs49LSmefSDu4pezGyR/JoRLh7QR4N3fC17V2E0GazWxvn2U985hPE3tvFcH+LM3EypVRCl6E9AiUZCeumqMBffyXw1AwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2eGyWcTM6Cpmkw6CBBxQbJCgp3Q4jyh+JR/Aqq5G+OFzxFpwlqW0dH9kNuUs30iSt1tt1gMZGYnhPKiGhtX3nV1iYg2K8k82wNqA5+ODfHxnnVn536UoC7rmjXL+mhpymxgkjGCQ+1HVmnCcSC9mxTPy65ihor+YZcRRPo0IhjQTx3NgdpzkGYvpQVjwnw3a5FpRBCbbp3X2x3EGV3DcjvT6DvvxSU/mAUPlXISo9OFHYUpADilqAevXQIs49LSmefSDu4pezGyR/JoRLh7QR4N3fC17V2E0GazWxvn2U985hPE3tvFcH+LM3EypVRCl6E9AiUZCeumqMBffyXw1AwIDAQAB" // NOLINT
   }), FilterList({
     "418D293D-72A8-4A28-8718-A1EE40A45AAF",
     "https://raw.githubusercontent.com/betterwebleon/slovenian-list/master/filters.txt", // NOLINT
@@ -281,7 +281,7 @@ const std::vector<FilterList> region_lists = {
     {"sl"},
     "https://github.com/betterwebleon/slovenian-list",
     "lddghfaofadfpaajgncgkbjhalgohfkd",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4cRSF2Rg5SSG6mwE6NQCnX4a0MfzC9URqNFnI4Wf3d3a7CkhmVeNZHxSCGGLxNV9SjCi5tko7NdMqIwnN/vliZV+jnEDi8Lj+zz9nftkaGXe3jNoP7tr/+Qkqphc76j3wIpsQx/vBnfVTn5lrNynZL6qpFzX5dj4ukdJ6BOx1YTNdJV9LOyMWbC5rno1mpd14aS7R2T6xfnm3+nupaZMAbUeN/1bwxDdND/mbjFzFvkPCC+4m758tI/5kSJOefy8kNvp9BM64LXPA4sF59ttJtCIOJDAyhM1P0Danyze2g/0GGnojDuzZilfeSCeEpDsc+S78Tyqz/lMtxt2LZkvoQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4cRSF2Rg5SSG6mwE6NQCnX4a0MfzC9URqNFnI4Wf3d3a7CkhmVeNZHxSCGGLxNV9SjCi5tko7NdMqIwnN/vliZV+jnEDi8Lj+zz9nftkaGXe3jNoP7tr/+Qkqphc76j3wIpsQx/vBnfVTn5lrNynZL6qpFzX5dj4ukdJ6BOx1YTNdJV9LOyMWbC5rno1mpd14aS7R2T6xfnm3+nupaZMAbUeN/1bwxDdND/mbjFzFvkPCC+4m758tI/5kSJOefy8kNvp9BM64LXPA4sF59ttJtCIOJDAyhM1P0Danyze2g/0GGnojDuzZilfeSCeEpDsc+S78Tyqz/lMtxt2LZkvoQIDAQAB" // NOLINT
   }), FilterList({
     "7DC2AC80-5BBC-49B8-B473-A31A1145CAC1",
     "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Filter.txt", // NOLINT
@@ -289,7 +289,7 @@ const std::vector<FilterList> region_lists = {
     {"sv"},
     "https://github.com/lassekongo83/Frellwits-filter-lists",
     "oimfmeehpinnecjghphifehbbnddjkmf",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA17Vf1qj8dWwYVtGpBHWc9gLiITU1XrTnb1sDASIeuKYp9JNBtEnBwy4oBlOoZd2uWFKxXrRtaimdwqa627gi9DB17t/RgzisXSpLubXbVVelRWllaX26SioGxsGcQhS2/e1Bc0inQ8GODM6mk5FPZ9RObFN1N/QVz35anN4VNcjtETD/XpujYXE1BU3C0KGBlWwc+cQZ6sGojWEPrb7aRXSTJ5y/ugwGomTTpbT+Jt9nFrMfuAmJHvWS0Ev96dDmn1zsuoPGUExVFjGBunphRYMVCg9LUGzY0FN5+dp6fljrTJrtUOEfvh40vmjahKd0w6bKpgTAOUEaWulmVSr37QIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA17Vf1qj8dWwYVtGpBHWc9gLiITU1XrTnb1sDASIeuKYp9JNBtEnBwy4oBlOoZd2uWFKxXrRtaimdwqa627gi9DB17t/RgzisXSpLubXbVVelRWllaX26SioGxsGcQhS2/e1Bc0inQ8GODM6mk5FPZ9RObFN1N/QVz35anN4VNcjtETD/XpujYXE1BU3C0KGBlWwc+cQZ6sGojWEPrb7aRXSTJ5y/ugwGomTTpbT+Jt9nFrMfuAmJHvWS0Ev96dDmn1zsuoPGUExVFjGBunphRYMVCg9LUGzY0FN5+dp6fljrTJrtUOEfvh40vmjahKd0w6bKpgTAOUEaWulmVSr37QIDAQAB" // NOLINT
   }), FilterList({
     "1BE19EFD-9191-4560-878E-30ECA72B5B3C",
     "https://adguard.com/filter-rules.html?id=13",
@@ -297,7 +297,7 @@ const std::vector<FilterList> region_lists = {
     {"tr"},
     "http://forum.adguard.com/forumdisplay.php?51-Filter-Rules",
     "oooemoeokehlgldpjjhcgbndjcekllim",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2We4hmp3TwsrKyOb6rF/mCjy9TW3w9n9CD1rZMXUF3U6CCgxH4lps5HiLlxUFaIhhcUEXrGlXbk4TE2LlTv4VS53O23YixZXQ/xMmpWSyBvc3/jBCrAAcvDLAZY53J1T/9t7DNZdpXkX3rNpYB4L5/5dyzQI+sZZoTBe5dLyJOR1uDZJphpXRWSKqBRLn4SJ5uOGgtqG5J4rMhB+SUrNhWs8AyM8+tdoaxOjx7n+PA2Rx7/foty1Bbd7Hfc1Eg0C9R40inJNgH+IDxZ07ZFqiAuY1Z16lr4bwunk7ft4tTafci0M2t86JkoH0B4yiTBKthB6AkmZ0/dejeQeOBszYQIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2We4hmp3TwsrKyOb6rF/mCjy9TW3w9n9CD1rZMXUF3U6CCgxH4lps5HiLlxUFaIhhcUEXrGlXbk4TE2LlTv4VS53O23YixZXQ/xMmpWSyBvc3/jBCrAAcvDLAZY53J1T/9t7DNZdpXkX3rNpYB4L5/5dyzQI+sZZoTBe5dLyJOR1uDZJphpXRWSKqBRLn4SJ5uOGgtqG5J4rMhB+SUrNhWs8AyM8+tdoaxOjx7n+PA2Rx7/foty1Bbd7Hfc1Eg0C9R40inJNgH+IDxZ07ZFqiAuY1Z16lr4bwunk7ft4tTafci0M2t86JkoH0B4yiTBKthB6AkmZ0/dejeQeOBszYQIDAQAB" // NOLINT
   }), FilterList({
     "6A0209AC-9869-4FD6-A9DF-039B4200D52C",
     "https://www.fanboy.co.nz/fanboy-vietnam.txt",
@@ -305,7 +305,7 @@ const std::vector<FilterList> region_lists = {
     {"vi"},
     "https://forums.lanik.us/",
     "cklgijeopkpaadeipkhdaodemoenlene",
-    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAymFhKEG/UJ8ZyKjdx4xfRFtECXdWXixG8GoS3mrw/haeVQoB1jXmPBQTZfL2WGZqYvrAkHRRel7XEoZNYziP3bCYbS4yVqKnDUp1u5GIsMsN0Pff1O1SHEbqClb79vAVhftNq1VQkHPpXQdoSiINQ12Om8WbOIuaNxkrTToFW7XRMtbI3tluoLUSy9YTkCEGah68Dl1uL6nOzOxaMV1iQRRk5Pw4ugTzwGHHL2U2kDYDNrlywK8cUIFgtZskqQ/TF1zF6u9xTGjwjB9X319XrTg2llcojCgj/dllBuXL2aJoDsS3qAVzqbSYxIE6bQU8JX8wv+KCDMpJt/dHPQqOMwIDAQAB"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAymFhKEG/UJ8ZyKjdx4xfRFtECXdWXixG8GoS3mrw/haeVQoB1jXmPBQTZfL2WGZqYvrAkHRRel7XEoZNYziP3bCYbS4yVqKnDUp1u5GIsMsN0Pff1O1SHEbqClb79vAVhftNq1VQkHPpXQdoSiINQ12Om8WbOIuaNxkrTToFW7XRMtbI3tluoLUSy9YTkCEGah68Dl1uL6nOzOxaMV1iQRRk5Pw4ugTzwGHHL2U2kDYDNrlywK8cUIFgtZskqQ/TF1zF6u9xTGjwjB9X319XrTg2llcojCgj/dllBuXL2aJoDsS3qAVzqbSYxIE6bQU8JX8wv+KCDMpJt/dHPQqOMwIDAQAB" // NOLINT
   })
 };
 

--- a/test/js/filteringTest.js
+++ b/test/js/filteringTest.js
@@ -1,10 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
-/* global describe, it */
+/* global describe, it, before, after */
 
+const http = require('http')
 const assert = require('assert')
-const {sanitizeABPInput} = require('../../lib/filtering')
+const {sanitizeABPInput, filterRareRulesPromise, setRareRuleDataUrl} = require('../../lib/filtering')
 const filteredOutRule = '*/test'
 const predicate = (rule) => !rule.startsWith('*')
 
@@ -37,6 +38,61 @@ describe('filtering', function () {
     it('Rebuilds lists which have multiple filtered out rules', function () {
       const rules = '&ad_channel=\n&ad_classid=\n&ad_height=\n&ad_keyword='
       assert(sanitizeABPInput(`${filteredOutRule}\n&ad_channel=\n${filteredOutRule}\n&ad_classid=\n&ad_height=\n&ad_keyword=`, predicate) === rules)
+    })
+  })
+  describe('filter out rare rules', function () {
+    const rareRuleText = [
+      '&ad_channel=',
+      '&ad_classid=',
+      '&ad_height=',
+      '&ad_keyword='
+    ].join('\n')
+    const testServer = http.createServer((req, res) => {
+      res.writeHead(200, {'Content-Type': 'text/plain'})
+      res.end(rareRuleText)
+    })
+
+    before(function (done) {
+      testServer.listen(0, '0.0.0.0', () => {
+        const testPort = testServer.address().port
+        setRareRuleDataUrl(`http://localhost:${testPort}/rules.txt`)
+        done()
+      })
+    })
+
+    after(function () {
+      testServer.close()
+    })
+
+    it('rules set as rare should be filtered', function (done) {
+      const testRules = [
+        '&ad_channel=', // This one should not be returned.
+        '.ad/'          // This one should.
+      ]
+      filterRareRulesPromise(testRules.join('\n'))
+        .then(results => {
+          const parsedResults = results.split('\n')
+          assert.equal(parsedResults.length, 1)
+          assert.equal(parsedResults[0], '.ad/')
+          done()
+        })
+    })
+
+    it('should be no change when no overlap with rare rules', function (done) {
+      const testRules = [
+        '.ad/',  // This one should be returned.
+        '.ad2/'  // This one should be returned too.
+      ]
+      filterRareRulesPromise(testRules.join('\n'))
+        .then(results => {
+          const parsedResults = results.split('\n')
+          assert.equal(parsedResults.length, 2)
+          assert(
+            (parsedResults[0] === '.ad/' && parsedResults[1] === '.ad2/') ||
+            (parsedResults[0] === '.ad2/' && parsedResults[1] === '.ad/')
+          )
+          done()
+        })
     })
   })
 })

--- a/test/js/matchingTest.js
+++ b/test/js/matchingTest.js
@@ -83,7 +83,7 @@ describe('matching', function () {
       assert.equal(this.client.getMatchingStats().numExceptionHashSetSaves, 1)
     })
   })
-  describe("no-fingerprint rules", function () {
+  describe('no-fingerprint rules', function () {
     it('can match against a no-fingerprint rule', function () {
       const client = new AdBlockClient()
       client.parse('adv')


### PR DESCRIPTION
Filters out EasyList rules that are not see in the crawl of Alexa1k (depth 2, breath 3), in the global, CN, DE and RU regions.

A couple of pieces that'd need to be worked out here:

1) the "rarely used" rules are pulled from `https://s3.amazonaws.com/com.brave.research.public/brave-unused-filters.txt`.  Might be better to put behind fastly or similar
2) That is generated by [this](https://github.com/brave/brave-unused-filter-builder) lambda function.  I have it running in Lambda under the "research" (i.e. non-production) AWS account, but would probably be good to move it somewhere else (and have it run regularly / cron'ed / etc somewhere).  I'm not sure what the best place is for this.  Whats the best way of getting this run once a day / week?
3) Since Brave doesn't apply CSS filters in anyway currently, every CSS rule is in the unused filters list.  This is correct for now, but will need to be changed going forward when we get that added in.
4) Should we kick out to Alexa10k?  Other regions?
5) Extend to EasyPrivacy?
6) @diracdeltas had a great idea for a possible further optimization:
    - Run the small subset of observed filters in blocking mode
    - Run the full set of EasyList / EasyPrivacy filters in non-blocking mode, and add hits to the blocking set. 

I think @diracdeltas 's idea is great, but would take bigger changes and maybe not worth blocking this on.  What do you think about doing that as a possible future change (and / or possible good first change for one of the interns working on blocking)?