### PR TITLE
Add "Malware Domain List" and "Malware domains" to malware_lists

### DIFF
--- a/lists/malware.h
+++ b/lists/malware.h
@@ -27,6 +27,22 @@ const std::vector<FilterList> malware_lists = {
     "https://disconnect.me/",
     "",
     ""
+  }), FilterList({
+    "E5484F0C-F35C-11E8-8EB2-F2801F1B9FD1",
+    "https://gitcdn.xyz/repo/NanoMeow/MDLMirror/master/hosts.txt",
+    "Malware Domain List",
+    {},
+    "http://www.malwaredomainlist.com/",
+    "",
+    ""
+  }), FilterList({
+    "237B68E0-F35D-11E8-8EB2-F2801F1B9FD1",
+    "https://mirror.cedia.org.ec/malwaredomains/justdomains",
+    "Malware domains",
+    {},
+    "https://www.malwaredomains.com/",
+    "",
+    ""
   })
 };
 

--- a/test/js/filterListTest.js
+++ b/test/js/filterListTest.js
@@ -38,8 +38,8 @@ describe('adBlockLists', function () {
     })
   })
   describe('malware', function () {
-    it('contains 2 malware lists', function () {
-      assert.equal(adBlockLists.malware.length, 2)
+    it('contains 4 malware lists', function () {
+      assert.equal(adBlockLists.malware.length, 4)
     })
     it('does not have langs property', function () {
       adBlockLists.malware.forEach((list) => {


### PR DESCRIPTION
There could be perf concerns for having too big of a list, but these
additional sources should be available as an option for those who prefer
the blocking to be as comprehensive as uBlock Origin.
Based on https://github.com/gorhill/uBlock/blob/e37cc238a772b1e51d9b2e2ea7ab33b14a12dc64/assets/assets.json#L171-L194.