### PR TITLE
update the -D option on cli to return full original rule text

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -7,13 +7,24 @@ const {sanitizeABPInput} = require('./filtering')
 const fs = require('fs')
 const {AdBlockClient, adBlockLists} = require('..')
 
-const makeAdBlockClientFromString = (filterRuleData) => {
+/**
+ * Builds an adblock client, given one or more strings containing filter rules.
+ *
+ * @param filterRuleData -- either a string, describing adblock filter riles,
+ *                          or an array of such strings.
+ * @param options        -- an optional object, describing parse options.
+ *                          currently the only used rule is "keepRuleText",
+ *                          which is a boolean flag determine whether to keep
+ *                          the original filter rule text.
+ */
+const makeAdBlockClientFromString = (filterRuleData, options) => {
+  const keepRuleText = !!(options && options.keepRuleText)
   return new Promise((resolve) => {
     const client = new AdBlockClient()
     if (filterRuleData.constructor === Array) {
-      filterRuleData.forEach(filterRuleDataItem => client.parse(filterRuleDataItem))
+      filterRuleData.forEach(filterRuleDataItem => client.parse(filterRuleDataItem, keepRuleText))
     } else {
-      client.parse(filterRuleData)
+      client.parse(filterRuleData, keepRuleText)
     }
     resolve(client)
   })
@@ -41,9 +52,13 @@ const makeAdBlockClientFromDATFile = (datFilePath) => {
  * Creates an ABlock client from a list URL
  * @param listURL - The URL to check for obtaining the list.
  * @param filter - A filtering function that can be optionally specified.
+ * @param options        -- an optional object, describing parse options.
+ *                          currently the only used rule is "keepRuleText",
+ *                          which is a boolean flag determine whether to keep
+ *                          the original filter rule text.
  * It will be called with the URL's body and it can filter and return a new string.
  */
-const getSingleListDataFromSingleURL = (listURL, filter) => {
+const getSingleListDataFromSingleURL = (listURL, filter, options) => {
   return new Promise((resolve, reject) => {
     request.get(listURL, function (error, response, body) {
       if (error) {
@@ -66,12 +81,17 @@ const getSingleListDataFromSingleURL = (listURL, filter) => {
 }
 
 /**
- * Creates an ABlock client from a list URL
- * @param listURL - The URL to check for obtaining the list.
- * @param filter - A filtering function that can be optionally specified.
+ * Creates an AdBlock client from a list URL
+ * @param listURL  -- The URL to check for obtaining the list.
+ * @param filter   -- A filtering function that can be optionally specified.
+ * @param options  -- an optional object, describing parse options.
+ *                    currently the only used rule is "keepRuleText",
+ *                    which is a boolean flag determine whether to keep
+ *                    the original filter rule text.
+
  * It will be called with the URL's body and it can filter and return a new string.
  */
-const makeAdBlockClientFromListURL = (listURL, filter) => {
+const makeAdBlockClientFromListURL = (listURL, filter, options) => {
   return new Promise((resolve, reject) => {
     if (listURL.constructor === Array) {
       const requestPromises = listURL.map((currentURL) => {
@@ -81,7 +101,7 @@ const makeAdBlockClientFromListURL = (listURL, filter) => {
       Promise.all(requestPromises).then((results) => {
         let body = results.join('\n')
         body = sanitizeABPInput(body)
-        resolve(makeAdBlockClientFromString(body))
+        resolve(makeAdBlockClientFromString(body, options))
       }).catch((error) => {
         console.error(`getSingleListDataFromSingleURL error: ${error}`)
         reject()
@@ -90,7 +110,7 @@ const makeAdBlockClientFromListURL = (listURL, filter) => {
       console.log(`${listURL}...`)
       getSingleListDataFromSingleURL(listURL, filter).then((listData) => {
         const body = sanitizeABPInput(listData)
-        resolve(makeAdBlockClientFromString(body))
+        resolve(makeAdBlockClientFromString(body, options))
       }).catch((error) => {
         console.error(`getSingleListDataFromSingleURL error: ${error}`)
         reject()
@@ -107,7 +127,19 @@ const getListFilterFunction = (uuid) => {
   return undefined
 }
 
-const makeAdBlockClientFromListUUID = (uuid) => {
+/**
+ * Creates an AdBlock client with the rules given in a list described by a UUID.
+ *
+ * See lists/* for the definitions of these UUIDs.
+ *
+ * @param uuid     -- a string, describing on of the UUIDs for a known filter
+ *                    list.
+ * @param options  -- an optional object, describing parse options.
+ *                    currently the only used rule is "keepRuleText",
+ *                    which is a boolean flag determine whether to keep
+ *                    the original filter rule text.
+ */
+const makeAdBlockClientFromListUUID = (uuid, options) => {
   let list = adBlockLists.default.find((l) => l.uuid === uuid)
   if (!list) {
     list = adBlockLists.regions.find((l) => l.uuid === uuid)
@@ -120,10 +152,20 @@ const makeAdBlockClientFromListUUID = (uuid) => {
   }
 
   const filterFn = getListFilterFunction(uuid)
-  return makeAdBlockClientFromListURL(list.listURL, filterFn)
+  return makeAdBlockClientFromListURL(list.listURL, filterFn, options)
 }
 
-const makeAdBlockClientFromFilePath = (filePath) => {
+/**
+ * Builds an adblock client by reading one or more files filter rules off disk.
+ *
+ * @param filePath -- either a string, describing the path to a file of filter
+ *                    rules on disk, or an array of the same.
+ * @param options  -- an optional object, describing parse options.
+ *                    currently the only used rule is "keepRuleText",
+ *                    which is a boolean flag determine whether to keep
+ *                    the original filter rule text.
+ */
+const makeAdBlockClientFromFilePath = (filePath, options) => {
   return new Promise((resolve, reject) => {
     let filterRuleData
     if (filePath.constructor === Array) {
@@ -131,7 +173,7 @@ const makeAdBlockClientFromFilePath = (filePath) => {
     } else {
       filterRuleData = fs.readFileSync(filePath, 'utf8')
     }
-    resolve(makeAdBlockClientFromString(filterRuleData))
+    resolve(makeAdBlockClientFromString(filterRuleData, options))
   })
 }
 

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -38,31 +38,39 @@ commander
   .option('-h, --host [host]', 'host of the page that is being loaded')
   .option('-l, --location [location]', 'URL to use for the check')
   .option('-o, --output [output]', 'Optionally saves a DAT file')
-  .option('-L --list [list]', 'Filename for list of sites to check')
-  .option('-D --discover', 'If speciied does filter discovery for matched filter')
-  .option('-s --stats', 'If speciied outputs parsing stats')
+  .option('-L, --list [list]', 'Filename for list of sites to check')
+  .option('-D, --discover', 'If specified does filter discovery for matched filter')
+  .option('-s, --stats', 'If specified outputs parsing stats')
   .option('-C, --cache', 'Optionally cache results and use cached results')
   .option('-O, --filter-option [filterOption]', 'Filter option to use', filterStringToFilterOption, FilterOptions.noFilterOption)
   .parse(process.argv)
 
-let p = Promise.reject('Usage: node check.js --location <location> --host <host> [--uuid <uuid>]')
+let p = Promise.reject(new Error('Usage: node check.js --location <location> --host <host> [--uuid <uuid>]'))
+
+const ruleDiscovery = commander.discover && !commander.dat
+const parseOptions = {
+  keepRuleText: !!ruleDiscovery,
+}
 
 if (commander.host && (commander.location || commander.list) || commander.stats) {
   p.catch(() => {})
   if (commander.uuid) {
-    p = makeAdBlockClientFromListUUID(commander.uuid)
+    p = makeAdBlockClientFromListUUID(commander.uuid, parseOptions)
   } else if (commander.dat) {
+    if (ruleDiscovery) {
+      console.log('Note, rule discovery is not supported when reading from DAT files')
+    }
     p = makeAdBlockClientFromDATFile(commander.dat)
   } else if (commander.http) {
-    p = makeAdBlockClientFromListURL(commander.http)
+    p = makeAdBlockClientFromListURL(commander.http, undefined, parseOptions)
   } else if (commander.filter) {
-    p = makeAdBlockClientFromString(commander.filter)
+    p = makeAdBlockClientFromString(commander.filter, parseOptions)
   } else if (commander.filterPath) {
-    p = makeAdBlockClientFromFilePath(commander.filterPath)
+    p = makeAdBlockClientFromFilePath(commander.filterPath, parseOptions)
   } else {
     const defaultLists = require('../').adBlockLists.default
       .map((listObj) => listObj.listURL)
-    p = makeAdBlockClientFromListURL(defaultLists)
+    p = makeAdBlockClientFromListURL(defaultLists, undefined, parseOptions)
   }
 }
 


### PR DESCRIPTION
Updated the check.js script to return the full, original rule text when the `-D` option is provided.  

Required updating the lib/util.js methods to all accept an extra options param.  Made an option so that future possible parse options could be included in the object, instead of a trailing line of arguments.