### PR TITLE
Fix incorrect handling of filters beginning with circumflex (^).

### DIFF
--- a/test/parser_test.cc
+++ b/test/parser_test.cc
@@ -339,6 +339,19 @@ TEST(client, exceptionRules) {
     {
       "http://yahoo.co.jp/promotion/imgs"
     }, {}));
+
+  CHECK(checkMatch("^ads^",
+    {
+      "http://yahoo.co.jp/ads/imgs",
+      "http://yahoo.co.jp/ads",
+      "http://yahoo.co.jp/ads?xyz",
+      "http://yahoo.co.jp/xyz?ads",
+    }, {
+      "http://yahoo.co.jp/uploads/imgs",
+      "http://yahoo.co.jp/adsx/imgs",
+      "http://yahoo.co.jp/adsshmads/imgs",
+      "ads://ads.co.ads/aads",
+    }));
 }
 
 struct OptionRuleData {


### PR DESCRIPTION
Basically reworked the string matching function, making it shorter
and simpler and added some tests.

Fix https://github.com/brave/ad-block/issues/150