### PR TITLE
add test and fix for passing an invalid serialized dat info to client deserialize

### DIFF
--- a/ad_block_client_wrap.cc
+++ b/ad_block_client_wrap.cc
@@ -323,6 +323,13 @@ void AdBlockClientWrap::Deserialize(const FunctionCallbackInfo<Value>& args) {
       String::NewFromUtf8(isolate, "Wrong number of arguments")));
     return;
   }
+
+  if (!args[0]->IsArrayBufferView()) {
+    isolate->ThrowException(v8::Exception::Error(
+      String::NewFromUtf8(isolate, "Provided string is not valid, serialized DAT data")));
+    return;
+  }
+
   unsigned char *buf = (unsigned char *)node::Buffer::Data(args[0]);
   size_t length = node::Buffer::Length(args[0]);
   const char *oldDeserializedData = obj->getDeserializedBuffer();

--- a/test/js/serializationTest.js
+++ b/test/js/serializationTest.js
@@ -45,12 +45,32 @@ describe('serialization', function () {
     assert(this.data.equals(data2))
   })
   it('deserializes with the same number of filters', function () {
-    const nonComentFilterCount = 11
-    assert.equal(this.client.getParsingStats().numFilters, nonComentFilterCount)
-    assert.equal(this.client2.getParsingStats().numFilters, nonComentFilterCount)
+    const nonCommentFilterCount = 11
+    assert.equal(this.client.getParsingStats().numFilters, nonCommentFilterCount)
+    assert.equal(this.client2.getParsingStats().numFilters, nonCommentFilterCount)
   })
   it('serialized data does not include comment data', function () {
     assert(!this.data.toString().includes('comment'))
     assert(!this.data.toString().includes('Adblock Plus'))
+  })
+
+  describe("deserializing input", function () {
+    it('does not throw on valid input', function () {
+      const client = new AdBlockClient()
+      client.deserialize(this.data)
+    })
+
+    it('throws on invalid input', function () {
+      const badInput = "not-good-data"
+      let caughtError = false
+      const newClient = new AdBlockClient()
+      // Check to make sure the below doesn't throw
+      try {
+        newClient.deserialize(badInput)
+      } catch (_) {
+        caughtError = true
+      }
+      assert(caughtError)
+    })
   })
 })


### PR DESCRIPTION
Passing an invalid string (something that wasn't generated from `client.serialize`) to `client.deserialize` crashes node.  

This PR includes a test and fix