### PR TITLE
Find matching filters should check 3p context

### DIFF
--- a/ad_block_client.cc
+++ b/ad_block_client.cc
@@ -927,6 +927,20 @@ bool AdBlockClient::findMatchingFilters(const char *input,
   int inputLen = static_cast<int>(strlen(input));
   int inputHostLen;
   const char *inputHost = getUrlHost(input, &inputHostLen);
+
+  int contextDomainLen = 0;
+  if (contextDomain) {
+    contextDomainLen = static_cast<int>(strlen(contextDomain));
+    if (isThirdPartyHost(contextDomain, contextDomainLen,
+        inputHost, static_cast<int>(inputHostLen))) {
+      contextOption =
+        static_cast<FilterOption>(contextOption | FOThirdParty);
+    } else {
+      contextOption =
+        static_cast<FilterOption>(contextOption | FONotThirdParty);
+    }
+  }
+
   hasMatchingFilters(noFingerprintFilters,
     numNoFingerprintFilters, input, inputLen, contextOption,
     contextDomain, nullptr,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-block",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ad-block",
   "main": "./build/Release/ad-block",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Ad block engine used in the Brave browser for ABP filter syntax based lists like EasyList.",
   "directories": {
     "test": "test"

--- a/test/js/matchingTest.js
+++ b/test/js/matchingTest.js
@@ -154,7 +154,7 @@ describe('matching', function () {
         assert.equal(queryResult.matchingOrigRule, '-google-analytics.')
       })
       it('exception rule returned', function () {
-        const queryResult = this.client.findMatchingFilters('https://www.scrumpoker.online/js/angular-google-analytics.js', FilterOptions.script, 'www.brianbondy.com')
+        const queryResult = this.client.findMatchingFilters('https://www.scrumpoker.online/js/angular-google-analytics.js', FilterOptions.script, 'www.scrumpoker.online')
         assert.equal(queryResult.matchingExceptionOrigRule, '@@||www.scrumpoker.online^$~third-party')
       })
       it('rules with multiple options', function () {
@@ -429,8 +429,30 @@ describe('matching', function () {
       })
     })
 
-
-
-
+    describe('first-party host', function() {
+      before(function () {
+        this.client = new AdBlockClient()
+        this.client.parse('analytics.brave.com^\n@@https://analytics.*/piwik.$~third-party')
+      })
+      it('for same host finds exception', function () {
+        assert(!this.client.matches('https://analytics.brave.com/piwik.js',
+            FilterOptions.image, 'analytics.brave.com'))
+      })
+      it('for same diff host does not find exception', function () {
+        assert(this.client.matches('https://analytics.brave.com/piwik.js',
+            FilterOptions.image, 'batcommunity.org'))
+      })
+      it('findMatchingFilters for same host finds exception', function () {
+        const queryResult = this.client.findMatchingFilters('https://analytics.brave.com/piwik.js', FilterOptions.script, 'analytics.brave.com')
+        assert.equal(queryResult.matches, false)
+        assert.equal(queryResult.matchingFilter, 'analytics.brave.com^')
+        assert.equal(queryResult.matchingExceptionFilter, 'https://analytics.*/piwik.')
+      })
+      it('findMatchingFilters for same diff host does not find exception', function () {
+        const queryResult = this.client.findMatchingFilters('https://analytics.brave.com/piwik.js', FilterOptions.script, 'batcommunity.org')
+        assert.equal(queryResult.matches, true)
+        assert.equal(queryResult.matchingFilter, 'analytics.brave.com^')
+      })
+    })
   })
 })


### PR DESCRIPTION
Originally ad-block clients needed to calculate if the context option was 3p or 1p by itself and tell the ad-block lib that.  Later we moved that to matches, but we never checked it in find matching filters.  

We now automaticlaly calculate it for clients using this function:
Fix https://github.com/brave/ad-block/issues/166