### PR TITLE
Rename test target to ad-block-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	./node_modules/node-gyp/gyp/gyp_main.py --generator-output=./build --depth=. -f ninja test/binding.gyp
 	./node_modules/node-gyp/gyp/gyp_main.py --generator-output=./build --depth=. -f xcode test/binding.gyp
 	ninja -C build/out/Default -f build.ninja
-	./build/out/Default/test || [ $$? -eq 0 ]
+	./build/out/Default/ad-block-test || [ $$? -eq 0 ]
 
 sample:
 	./node_modules/node-gyp/gyp/gyp_main.py --generator-output=./build --depth=. -f ninja sample/binding.gyp

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -1,6 +1,6 @@
 {
   "targets": [{
-    "target_name": "test",
+    "target_name": "ad-block-test",
     "type": "executable",
     "sources": [
       "../test/test_main.cc",


### PR DESCRIPTION
Fix https://github.com/brave/ad-block/issues/168

This avoids a problem on some configs were it raced with cppunitlite test target