### PR TITLE
Fix bug in regex parsing

### DIFF
--- a/ad_block_client.cc
+++ b/ad_block_client.cc
@@ -334,7 +334,7 @@ void parseFilter(const char *input, const char *end, Filter *f,
           }
           break;
         case '/': {
-          const size_t inputLen = strlen(input);
+          const size_t inputLen = end - input;
           if (parseState == FPStart || parseState == FPPastWhitespace) {
             if (input[inputLen - 1] == '/' && inputLen > 1) {
               // Just copy out the whole regex and return early

--- a/test/js/parsingTest.js
+++ b/test/js/parsingTest.js
@@ -89,4 +89,32 @@ describe('parsing', function () {
       })
     })
   })
+  describe('regex parsing', function () {
+    // See https://github.com/brave/ad-block/issues/173 for details
+    it('regex should not check last character of input buffer', function (cb) {
+      makeAdBlockClientFromString('/filter1\nfilter2/').then((client) => {
+        // regex are considered noFingerprintFilters
+        assert.equal(client.getFilters('filters').length, 2)
+        cb()
+      })
+    })
+    it('regex should not be a no fingerprint filter', function (cb) {
+      makeAdBlockClientFromString('/filter1/\nfilter2/').then((client) => {
+        // regex are considered noFingerprintFilters
+        assert.equal(client.getFilters('filters').length, 1)
+        assert.equal(client.getFilters('noFingerprintFilters').length, 1)
+        cb()
+      })
+    })
+    // See https://github.com/brave/ad-block/issues/173 for details
+    it('should serialize correctly', function (cb) {
+      makeAdBlockClientFromString('/filter1\nfilter2/\n').then((client) => {
+        makeAdBlockClientFromString('/filter1\nfilter2/').then((client2) => {
+          // regex are considered noFingerprintFilters
+          assert.equal(client.serialize().length, client2.serialize().length)
+          cb()
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
We were wrongly checking end of the input buffer to see if a filter was a regex, instead of the end of the filter.  So if the file ended in a slash then we would store a big regex of the length from the start of the regex to the end of the file as the regex itself, then continue parsing as usual from the next filter correctly.

If the last line ended with a newline it would always detect things to not be regexs.

This has no effect on clients since they don't parse things, they just use already created DAT files.

Fix https://github.com/brave/ad-block/issues/173