### PR TITLE
Use upstream uBlock unbreak list directly (fixes brave/adblock-lists#52)

### DIFF
--- a/lists/default.h
+++ b/lists/default.h
@@ -38,7 +38,7 @@ const std::vector<FilterList> default_lists = {
     ""
   }, {
     "200392E7-9A0F-40DF-86EB-6AF7E4071322",
-    "https://raw.githubusercontent.com/brave/adblock-lists/master/ublock-unbreak.txt", // NOLINT
+    "https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt", // NOLINT
     "uBlock Unbreak",
     {},
     "https://github.com/gorhill/uBlock",


### PR DESCRIPTION
This fixes brave/adblock-lists#52.

I have build the `dat` file with this change and didn't see any errors in this list. I also tested the generated `dat` file in Beta and saw ads blocked on CNN, as expected.

If this is accepted, I'll file another PR to remove `ublock-unbreak.txt` from the `brave/adblock-lists` repo.