### PR TITLE
Use a maintained Spam404 repo (fixes #184)

### DIFF
--- a/lists/malware.h
+++ b/lists/malware.h
@@ -12,7 +12,7 @@
 const std::vector<FilterList> malware_lists = {
   FilterList({
     "AE08317A-778F-4B95-BC12-7E78C1FB26A3",
-    "https://raw.githubusercontent.com/Dawsey21/Lists/master/adblock-list.txt",
+    "https://raw.githubusercontent.com/Spam404/lists/master/adblock-list.txt",
     "Spam404 Domain Blacklist",
     {},
     "http://www.spam404.com/domain-blacklist.html",


### PR DESCRIPTION
Fixes #184.

I was able to generate the `SafeBrowsingData.dat` file without any errors.