### PR TITLE
Only determine third-party when needed

### DIFF
--- a/ad_block_client.cc
+++ b/ad_block_client.cc
@@ -753,7 +753,8 @@ bool AdBlockClient::matches(const char* input, FilterOption contextOption,
   const char *inputHost = getUrlHost(input, &inputHostLen);
 
   int contextDomainLen = 0;
-  if (contextDomain) {
+  // If neither first party nor third party was specified, try to figure it out
+  if (contextDomain && !(contextOption & (FOThirdParty | FONotThirdParty))) {
     contextDomainLen = static_cast<int>(strlen(contextDomain));
     if (isThirdPartyHost(contextDomain, contextDomainLen,
         inputHost, static_cast<int>(inputHostLen))) {
@@ -943,7 +944,8 @@ bool AdBlockClient::findMatchingFilters(const char *input,
   const char *inputHost = getUrlHost(input, &inputHostLen);
 
   int contextDomainLen = 0;
-  if (contextDomain) {
+  // If neither first party nor third party was specified, try to figure it out
+  if (contextDomain && !(contextOption & (FOThirdParty | FONotThirdParty))) {
     contextDomainLen = static_cast<int>(strlen(contextDomain));
     if (isThirdPartyHost(contextDomain, contextDomainLen,
         inputHost, static_cast<int>(inputHostLen))) {


### PR DESCRIPTION
See also:
https://github.com/brave/brave-core/pull/1813

See also:
https://github.com/brave/brave-browser/issues/3535


Basically this will only set the `FOThirdParty` and `FONotThirdParty` flags internally if we didn't specify them when calling `match`.
This is to get past a problem where the library doesn't calculate it correctly with an easy fix in brave-core.