### PR TITLE
Fix deserialized host anchored domain only filter matching

### DIFF
--- a/no_fingerprint_domain.cc
+++ b/no_fingerprint_domain.cc
@@ -87,6 +87,8 @@ uint32_t NoFingerprintDomain::Deserialize(char *buffer, uint32_t bufferSize) {
   data = buffer + consumed;
   consumed += dataLen;
   borrowed_data = true;
+  // Since we serialize a \0 character, we need to skip past it.
+  consumed++;
   return consumed;
 }
 

--- a/test/js/matchingTest.js
+++ b/test/js/matchingTest.js
@@ -71,6 +71,21 @@ describe('matching', function () {
       assert.equal(this.client.getMatchingStats().numExceptionHashSetSaves, 1)
     })
   })
+  describe('domain only host anchored filters', function () {
+    before(function () {
+      this.client = new AdBlockClient()
+      this.client.parse('||imasdk.googleapis.com^$third-party\n@@||imasdk.googleapis.com/js/sdkloader/ima3.js$domain=cbc.ca|cbsnews.com|cbssports.com')
+      const data = this.client.serialize()
+      this.client2 = new AdBlockClient()
+      this.client2.deserialize(data)
+    })
+    it('should match exception filter from normal parsed list', function () {
+      assert(!this.client2.matches('https://imasdk.googleapis.com/js/sdkloader/ima3.js?v=1.0fc2a9c5e010611944b364a71d43c8b5099f209f', FilterOptions.script, 'www.cbsnews.com'))
+    })
+    it('should match exception filter from deserialized list', function () {
+      assert(!this.client.matches('https://imasdk.googleapis.com/js/sdkloader/ima3.js?v=1.0fc2a9c5e010611944b364a71d43c8b5099f209f', FilterOptions.script, 'www.cbsnews.com'))
+    })
+  })
   describe('host anchored exception with not matching first party exception', function () {
     before(function () {
       this.client = new AdBlockClient()


### PR DESCRIPTION
Back several months ago when we added EasyPrivacy support we added a perf optimization to make that possible for domain only host anchored filters. 
This is stored last in the serialization file, so we didn't see any fallout.

The situation is described more in the issue below.

FIx https://github.com/brave/ad-block/issues/190
